### PR TITLE
Basic startup of traefik & drupal labels

### DIFF
--- a/.env
+++ b/.env
@@ -104,6 +104,17 @@ TOMCAT_LOCALHOST_LOG=WARNING
 TOMCAT_LOCALHOST_MANAGER_LOG=WARNING
 TOMCAT_LOCALHOST_HOST_MANAGER_LOG=WARNING
 
+# Traefik
+TRAEFIK_LOG_LEVEL=DEBUG
+TRAEFIK_PROVIDERS_DOCKER=true
+TRAEFIK_PROVIDERS_DOCKER_EXPOSEDBYDEFAULT=false
+## TRAEFIK_ENTRYPOINTS_<NAME>_ADDRESS
+TRAEFIK_ENTRYPOINTS_WEB_ADDRESS=:80
+TRAEFIK_ENTRYPOINTS_WEBSECURE_ADDRESS=:443
+## Enabling access to the Traefik interface is not safe in a production environment unless you have the ISLE system behind a firewall and only ports 80 and 443 exposed.
+TRAEFIK_API=false
+TRAEFIK_API_DASHBOARD=false
+TRAEFIK_API_INSECURE=false
 
 ## Matomo
 # TO DO: Determine what ENVs are necessary for configuration or startup.

--- a/config/traefik/traefik.local.yml
+++ b/config/traefik/traefik.local.yml
@@ -1,0 +1,42 @@
+log:
+  level: "DEBUG"
+  format: "json"
+  filePath: "/var/log/traefik/traefik.log"
+
+accessLog:
+  filePath: "/var/log/traefik/access.log"
+  bufferingSize: 100
+
+providers:
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    exposedByDefault: false 
+  # Todo: optional alternative to docker-compose labels
+  # file:
+    # directory: "/etc/traefik/traefik.d/"
+    #   watch: true
+
+## Static configuration
+entryPoints:
+  web:
+    address: ":80"
+
+  web-secure:
+    address: ":443"
+
+#  web-admin:
+#    address: ":8080"
+
+# ToDo: Choice #1 - add resolver in production: 
+# certificatesResolvers:
+#  leresolver:
+#    acme:
+#      email: "cwrc@ualberta.ca"
+#      storage: "/var/letsencrypt/acme.json"
+#      httpChallenge:
+#        entryPoint: "web"
+
+api:
+  insecure: false
+  #insecure: true
+  #dashboard: true

--- a/config/traefik/traefik.local.yml
+++ b/config/traefik/traefik.local.yml
@@ -1,11 +1,5 @@
 log:
-  level: "DEBUG"
-  format: "json"
-  filePath: "/var/log/traefik/traefik.log"
-
-accessLog:
-  filePath: "/var/log/traefik/access.log"
-  bufferingSize: 100
+  level: "ERROR"
 
 providers:
   docker:
@@ -38,5 +32,6 @@ entryPoints:
 
 api:
   insecure: false
-  #insecure: true
-  #dashboard: true
+  # uncomment to enable
+  # insecure: true
+  # dashboard: true

--- a/docker-compose.mvp1.yml
+++ b/docker-compose.mvp1.yml
@@ -6,7 +6,6 @@ version: '3.7'
 
 services:
 
-
   traefik:
     # review https://hub.docker.com/_/traefik
     image: traefik:2.1.3
@@ -21,6 +20,8 @@ services:
       - "443:443"
       #- "8080:8080"
     volumes:
+      # TO DO: local deployment placeholder
+      - "./config/traefik/traefik.local.yml:/etc/traefik/traefik.yml"
       # TO DO: Update according to new Traefik 2.0 conventions (values below based on 1.7.9, are incomplete & wrong due to missing "routing" labels)
       - /var/run/docker.sock:/var/run/docker.sock
       # SSL Choice 1: To use Let's Encrypt for SSL- uncomment ONLY the line below and then create an empty config/traefik/acme.json file
@@ -29,12 +30,14 @@ services:
       # - ./config/traefik/ssl-certs:/certs:ro
       # TO DO: Determine if toml files are still to be bound in Traefik 2.0
     # TO DO: Update according to new Traefik 2.0 conventions (values below based on 1.7.9, are incomplete & wrong due to missing "routing" labels)
-    labels:
-      - traefik.port=8080
+#    labels:
+#      - traefik.port=8080
       ## Enabling access to the Traefik interface is not safe in a production environment unless you have the ISLE system behind a firewall and only ports 80 and 443 exposed.
-      - traefik.enable=false
-      - traefik.frontend.rule=Host:admin.${BASE_DOMAIN};
+#      - traefik.enable=false
+#      - traefik.frontend.rule=Host:admin.${BASE_DOMAIN};
 
+    command:
+      - "--configFile=/etc/traefik/traefik.yml"
  
   drupal:
     # review https://github.com/docker-library/docs/blob/master/drupal/content.md
@@ -61,7 +64,11 @@ services:
       - ./data/drupal/themes:/var/www/html/themes
       # TO DO: Determine what type of container handling is needed
     restart: always
-
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.drupal.rule=Host(`${DOMAIN}`)"
+      # TO DO: setup web-secure
+      - "traefik.http.routers.drupal.entrypoints=web,web-secure"
  
 ## TO DO: Break this section out into another Docker-compose for extension https://docs.docker.com/compose/extends/ and as an conditional either mysql or postgres
   mysql:
@@ -85,7 +92,7 @@ services:
 
 
   solr:
-    image: solr/solr:8.4.1
+    image: solr:8.4.1
     container_name: isle-dc-solr-${CONTAINER_SHORT_ID}
     environment:
       - JAVA_MAX_MEM=2048M

--- a/docker-compose.mvp1.yml
+++ b/docker-compose.mvp1.yml
@@ -20,24 +20,20 @@ services:
       - "443:443"
       #- "8080:8080"
     volumes:
-      # TO DO: local deployment placeholder
-      - "./config/traefik/traefik.local.yml:/etc/traefik/traefik.yml"
       # TO DO: Update according to new Traefik 2.0 conventions (values below based on 1.7.9, are incomplete & wrong due to missing "routing" labels)
       - /var/run/docker.sock:/var/run/docker.sock
       # SSL Choice 1: To use Let's Encrypt for SSL- uncomment ONLY the line below and then create an empty config/traefik/acme.json file
       # - ./config/traefik/acme.json:/acme.json
       # SSL Choice 2: To use commercial SSLs - uncomment ONLY the line below. Add your SSL certs (.cert, .pem, .key) files to config/traefik/ssl-certs
       # - ./config/traefik/ssl-certs:/certs:ro
-      # TO DO: Determine if toml files are still to be bound in Traefik 2.0
-    # TO DO: Update according to new Traefik 2.0 conventions (values below based on 1.7.9, are incomplete & wrong due to missing "routing" labels)
-#    labels:
-#      - traefik.port=8080
-      ## Enabling access to the Traefik interface is not safe in a production environment unless you have the ISLE system behind a firewall and only ports 80 and 443 exposed.
-#      - traefik.enable=false
-#      - traefik.frontend.rule=Host:admin.${BASE_DOMAIN};
+  
+      # Use Environment vaiables to pass in Traefik config not supplied 
+      # by providers
+      # Alternative to a static configureation /etc/traefik/traefik.yml"
+      # Pass in config via flags or environment variables
+      # https://docs.traefik.io/getting-started/configuration-overview
+      # Obsolete - "./config/traefik/traefik.local.yml:/etc/traefik/traefik.yml"
 
-    command:
-      - "--configFile=/etc/traefik/traefik.yml"
  
   drupal:
     # review https://github.com/docker-library/docs/blob/master/drupal/content.md


### PR DESCRIPTION
First step: basic http port 80 Traefik route to the Drupal container
* fix docker-compose startup problem
* add entry points for 80 and 443
* add traefik labels for drupal

To test:
* clone repo
* ` docker-compose -f docker-compose.mvp1.yml pull`
* ` docker-compose -f docker-compose.mvp1.yml up -d`
* on linux, add `idcp.localdomain` to `/etc/hosts` as an alias for localhost
* ` lynx http://idcp.localdomain:80/`
* if this works, one should see a Drupal 8.8.1 Installation tasks

Where `idcp.localdomain` is the `.env` DOMAIN property


