### PR TITLE
Add alpaca connectors and activemq

### DIFF
--- a/.env
+++ b/.env
@@ -119,3 +119,47 @@ TRAEFIK_ENTRYPOINTS_WEBSECURE_ADDRESS=:443
 TRAEFIK_API=false
 TRAEFIK_API_DASHBOARD=false
 TRAEFIK_API_INSECURE=false
+
+
+# Activemq address
+ACTIVEMQ_URL=tcp://activemq:61616
+
+# These serve both to set the activeMQ password, and configure alpaca to use it
+ACTIVEMQ_USER=isle
+ACTIVEMQ_PASSWORD=moo
+
+# JWT creds for Alpaca to connect to Fedora
+ALPACA_HTTP_TOKEN=islandora
+
+# Houdini connector
+ALPACA_HOUDINI_QUEUE=broker:queue:islandora-connector-houdini
+ALPACA_HOUDINI_DERIVATIVE_SERVICE_URL=http://houdini:8000/convert
+
+# Homarus connector
+ALPACA_HOMARUS_QUEUE=broker:queue:islandora-connector-homarus
+ALPACA_HOMARUS_DERIVATIVE_SERVICE_URL=http://homarus:8000/convert
+
+# OCR connector
+ALPACA_OCR_QUEUE=broker:queue:islandora-connector-ocr
+ALPACA_OCR_DERIVATIVE_SERVICE_URL=http://ocr:8000/hypercube
+
+# FITS connector
+ALPACA_FITS_QUEUE=broker:queue:islandora-connector-fits
+ALPACA_FITS_DERIVATIVE_SERVICE_URL=http://fits:8000/crayfits
+
+# Fcrepo connector
+ALPACA_FCREPO_FILE_STREAM=broker:queue:islandora-indexing-fcrepo-file
+ALPACA_FCREPO_FILE_DELETE_STREAM=broker:queue:islandora-indexing-fcrepo-file-delete
+ALPACA_FCREPO_NODE_STREAM=broker:queue:islandora-indexing-fcrepo-content
+ALPACA_FCREPO_NODE_DELETE_STREAM=broker:queue:islandora-indexing-fcrepo-delete
+ALPACA_FCREPO_MEDIA_STREAM=broker:queue:islandora-indexing-fcrepo-media
+ALPACA_FCREPO_MILLINER_BASEURL=http://milliner:8000/milliner/
+ALPACA_FCREPO_GEMINI_BASEURL=http://gemini:8000/gemini/
+
+# Triplestore connector
+ALPACA_INDEXING_TRIPLESTORE_BASEURI=http://triplestore:8080/bigdata/namespace/islandora/sparql
+ALPACA_INDEXING_TRIPLESTORE_QUEUE=broker:activemq:queue:islandora-indexing-triplestore-index
+ALPACA_INDEXING_TRIPLESTORE_DELETE_QUEUE=broker:queue:islandora-indexing-triplestore-delete
+ALPACA_INDEXING_TRIPLESTORE_FCREPO_QUEUE=broker:topic:fedora
+ALPACA_INDEXING_TRIPLESTORE_FCREPO_REINDEXING_QUEUE=broker:queue:triplestore.reindex
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,18 @@ services:
       # https://docs.traefik.io/getting-started/configuration-overview
       # Obsolete - "./config/traefik/traefik.local.yml:/etc/traefik/traefik.yml"
 
+  alpaca-connector:
+    container_name: "${PROJECT_NAME}_alpaca"
+    image: birkland/isle-alpaca@sha256:9fdf260df79b38fd240192ec618e4eec74cca2b6157b4e59f7d4792295cfe210
+    env_file: .env
+
+  activemq:
+    image: oapass/activemq:20200219
+    container_name: "${PROJECT_NAME}_activemq"
+    env_file: .env
+    ports:
+      - "8161:8161"  # To make mgmt console available for dev purposes.  use admin:admin to log in
+
 
 networks:
   internal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,8 @@ services:
     container_name: "${PROJECT_NAME}_alpaca"
     image: birkland/isle-alpaca@sha256:9fdf260df79b38fd240192ec618e4eec74cca2b6157b4e59f7d4792295cfe210
     env_file: .env
+    networks:
+      - internal
 
   activemq:
     image: oapass/activemq:20200219
@@ -139,6 +141,8 @@ services:
     env_file: .env
     ports:
       - "8161:8161"  # To make mgmt console available for dev purposes.  use admin:admin to log in
+    networks:
+      - internal
 
 
 networks:


### PR DESCRIPTION
Adds a single Karaf instance containing all connectors, config to run them, and an activemq instance

## To Test
* `docker-compose up -d` (this should pull in all images, if not do a `docker-compose pull` first
* Go to `http://localhost:8161`, which is the ActiveMQ admin console.  Click on "Manage ActiveMQ broker".  Enter in username `admin`, pass `admin`
* Click on the `queues` tab.  You should see all the queues the connectors listen to. 
* Now, pick a service (maybe fits) and remember it.  Shut everything down `docker-compose down -v`
* To to the `.env` file and comment out the env vars for that service.  This will disable it.
* Start up `docker-compose up -d`
* log into ActiveMQ.  Look at the queues, and observe the one that corresponds to your service doesn't exist.  This proves you can shut them off at will

There isn't much more to test, since services aren't connected.  This PR just verifies that camel routes start successfully, connect to the messaging bus and eagerly await messages that never come.