### PR TITLE
Remove blazegraph local bind mount designation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -343,10 +343,5 @@ volumes:
   activemq-data:
   solr-data:
   blazegraph-data:
-    driver: local
-    driver_opts:
-      type: none
-      o: bind
-      device: ${PWD}/data/blazegraph/data
 
   # isle-dc-postgres-data # Added to prototype but not currently used    


### PR DESCRIPTION
Brings blazegraph mount in line with the other volumes

Resolves #66