### PR TITLE
Mount codebase as /app for containerized composer

### DIFF
--- a/scripts/drupal/init.sh
+++ b/scripts/drupal/init.sh
@@ -44,7 +44,7 @@ function download_drupal() {
 
   # Delete codebase just in case a previous command failed to finish the installation.
   [[ -d ./codebase ]] && rm -rf ./codebase
-  $composer $args $composer_general_flags codebase
+  $composer $args $composer_general_flags .
 
   download_required_packages
 }
@@ -149,9 +149,9 @@ if [[ ! $composer ]]; then
   echo >&2
   mkdir -p "$HOME/.composer"
   if $is_darwin; then
-    composer="docker container run -it --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD:/app composer:1.9.3"
+    composer="docker container run -it --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD/codebase:/app composer:1.9.3"
   else
-    composer="env MSYS_NO_PATHCONV=1 docker container run -t --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD:/app composer:1.9.3"
+    composer="env MSYS_NO_PATHCONV=1 docker container run -t --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD/codebase:/app composer:1.9.3"
   fi
 fi
 
@@ -179,7 +179,7 @@ mkdir -p $PWD/data/drupal/files/public $PWD/data/drupal/files/private
 ###
 if [[ ! -f "$current_folder/codebase/vendor/autoload.php" ]]; then
   cd "$current_folder/codebase"
-  $composer install $composer_flags
+  $composer install $composer_general_flags
   cd ..
 fi
 


### PR DESCRIPTION
This allows the init.sh script to work properly both for creating a new project, and for using an existing project cloned into `codebase`

## To test

To see this problem in `development`, to the following in `isle-dc`
* `git clone https://github.com/Born-Digital-US/drupal-project.git codebase`
* make

You'll see a failure:
```
Composer could not find a composer.json file in /app
To initialize a project, please create a composer.json file as described in the https://getcomposer.org/ "Getting Started" section
make: *** [Makefile:15: drupal_init] Error 1
```

Now, try the same with this PR.  You'll see that `composer.json` is found.  (At present, the `make` process will fail due to a dependency resolution issue, which is irrelevant to this PR)

Resolves #69
