### PR TITLE
Allow REQUIRED_SERVICES override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export
 EXTERNAL_SERVICES := etcd watchtower traefik
 
 # The minimal set of docker-compose files required to be able to run anything.
-REQUIRED_SERIVCES := activemq alpaca blazegraph cantaloupe crayfish crayfits drupal fcrepo mariadb matomo solr
+REQUIRED_SERIVCES ?= activemq alpaca blazegraph cantaloupe crayfish crayfits drupal fcrepo mariadb matomo solr
 
 # Watchtower is an optional dependency, defaults to not being included.
 ifeq ($(INCLUDE_WATCHTOWER_SERVICE), true)


### PR DESCRIPTION
Primarily for the use case of running ISLE without Fedora, this allows a developer to define the set of services he or she wishes to deploy by way of defining `REQUIRED_SERVICES` in the local `.env` file.