### PR TITLE
Adds delegated flag to website codebase volume

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -18,7 +18,7 @@ services:
   drupal:
     image: ${REPOSITORY:-islandora}/drupal:${TAG:-latest}
     volumes:
-      - ./codebase:/var/www/drupal
+      - ./codebase:/var/www/drupal:delegated
       - drupal-sites-data:/var/www/drupal/web/sites/default/files
       - solr-data:/opt/solr/server/solr
     depends_on:


### PR DESCRIPTION
This helps to address issue #93 by adding a `delegated` flag onto the website codebase volume for the drupal service. 
 
I was seeing the modules page (Manage->Extend) take almost 30 s to load, now it is down to 7-9 s.  Other pages load in 1-3 seconds now.   