### PR TITLE
Some versions of CURL and OpenSSL need fullchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ endif
 download-default-certs:
 	mkdir -p certs
 	if [ ! -f certs/cert.pem ]; then \
-		curl http://traefik.me/cert.pem -o certs/cert.pem; \
+		curl http://traefik.me/fullchain.pem -o certs/cert.pem; \
 	fi
 	if [ ! -f certs/privkey.pem ]; then \
 		curl http://traefik.me/privkey.pem -o certs/privkey.pem; \


### PR DESCRIPTION
While the simple "cert.pem" file works for some situations, some security settings seem to require the fullchain.pem. There appears to be no downside to using fullchain instead. I left the filename the same so you don't need to edit `tls.yml`.