### PR TITLE
Adds ability to override DATABASE_SERVICES env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ endif
 # Some services can optionally depend on PostgreSQL.
 # Either way their environment variables get customized
 # depending on the database service they have choosen.
-DATABASE_SERVICES := drupal.$(DRUPAL_DATABASE_SERVICE) fcrepo.$(FCREPO_DATABASE_SERVICE) crayfish.$(GEMINI_DATABASE_SERVICE)
+DATABASE_SERVICES ?= drupal.$(DRUPAL_DATABASE_SERVICE) fcrepo.$(FCREPO_DATABASE_SERVICE) crayfish.$(GEMINI_DATABASE_SERVICE)
 
 ifeq ($(DRUPAL_DATABASE_SERVICE), postgresql)
 	DATABASE_SERVICES += postgresql


### PR DESCRIPTION
This just changes `:=` to `?=` when assigning DATABASE_SERVICES for the first time. This allows us to include DATABASE_SERVICES in the .env file and override which services are available (like we can with REQUIRED_SERIVCES).  In our case, we don't have fcrepo enabled, so this gives us the flexibility to take it out of the db services setup as well. 