### PR TITLE
Fixes variables in maria db docker compose file

### DIFF
--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -31,6 +31,6 @@ services:
         # name in settings.php so Drush on the host machine can be used in the
         # codebase folder.
         aliases:
-          - mariadb-${compose_project_name-isle-dc}.${drupal_site_host-traefik.me}
-          - mariadb-${compose_project_name-isle-dc}-${drupal_site_host-traefik.me}
+          - mariadb-${COMPOSE_PROJECT_NAME-isle-dc}.${DRUPAL_SITE_HOST-traefik.me}
+          - mariadb-${COMPOSE_PROJECT_NAME-isle-dc}-${DRUPAL_SITE_HOST-traefik.me}
       gateway:


### PR DESCRIPTION
Fixes typo where some env variables were lower case instead of upper. Resulted in things not working correctly. 