### PR TITLE
Mention resource requirements and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,16 @@ supports:
 To quickly get started, we recommend running the [demo](#-demo) environment
 first after you have completed the [Installation](#-installation).
 
+A walkthrough for setting up a simple local installation is available in the
+Islandora documentation: [Install Islandora on Docker (ISLE)](https://islandora.github.io/documentation/installation/docker-compose/)
+
 ## Requirements
 
 - Composer 1.10+
-- Desktop / laptop / VM (*Must be able to support running GNU Make*)
-- Docker-CE 19.x+ (If using Docker Desktop for Windows, any stable release
+- Desktop / laptop / VM (*Docker must have sufficient resources to run GNU Make*)
+- Docker-CE 19.x+ (*If using Docker Desktop for Windows, any stable release
   *after* 2.2.0.4, or use a 2.2.0.4 with a [patch][Docker for Windows Patch] due
-  to a [bug][Docker for Windows Bug])
+  to a [bug][Docker for Windows Bug]*)
 - Docker-compose version 1.25.x+
 - Drush 9.0+
 - Git 2.0+


### PR DESCRIPTION
There is no indication in the README that Docker Desktop's default settings need to be changed. Rather than declaring "8GB memory available to Docker" as a requirement (probably isn't), I alluded to it needing to be "available to docker" - hopefully will prevent more people from consistently running into OOM errors and not knowing what to do.

It's clealry documented in the ISLE docs that I wrote, but those aren't acknowledged from the README either, so I tried to place it in context as "a simple walkthrough for a local installation"
