### PR TITLE
Use a commit hash since latest can't be trusted

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -57,7 +57,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=latest
+TAG=6f188321dbef0f3f366fe9dd20ae238fcd023491 
 
 ###############################################################################
 # Global Environment variables


### PR DESCRIPTION
This will fix `main`, which is broken right now due to `latest` being unstable.  Just patching the hole in the boat before I make a stable and dev tags