### PR TITLE
remove extra space character from the sample.env TAG environment vararible

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -57,7 +57,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=6f188321dbef0f3f366fe9dd20ae238fcd023491 
+TAG=6f188321dbef0f3f366fe9dd20ae238fcd023491
 
 ###############################################################################
 # Global Environment variables


### PR DESCRIPTION
The `sample.env` TAG value contains a space character at the end of the line. When the `make` command is run when no `docker-compose.yml` file exists then the `docker-compose.yml` file image property points to an invalid image: `image: 'islandora/solr:6f188321dbef0f3f366fe9dd20ae238fcd023491 '. If one removes the space character after the hash in in image name (before the single quote) the error goes away.

This PR removes the space character.

Example of the steps to create the error (assumes an installed and configured docker and docker-compose):

```
[centos@cc-dev-01 tmp]$ git clone https://github.com/islandora-devops/isle-dc
Cloning into 'isle-dc'...
remote: Enumerating objects: 2033, done.
remote: Total 2033 (delta 0), reused 0 (delta 0), pack-reused 2033
Receiving objects: 100% (2033/2033), 43.56 MiB | 6.62 MiB/s, done.
Resolving deltas: 100% (1099/1099), done.

[centos@cc-dev-01 tmp]$ cd isle-dc/

[centos@cc-dev-01 isle-dc]$ make
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3436  100  3436    0     0  11192      0 --:--:-- --:--:-- --:--:-- 11155
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1708  100  1708    0     0   5951      0 --:--:-- --:--:-- --:--:--  5951
docker-compose pull
Pulling activemq   ... error
Pulling alpaca     ... error
Pulling blazegraph ... error
Pulling cantaloupe ... error
Pulling fcrepo     ... error
Pulling fits       ... error
Pulling crayfits   ... error
Pulling gemini     ... error
Pulling homarus    ... error
Pulling houdini    ... error
Pulling hypercube  ... error
Pulling mariadb    ... error
Pulling matomo     ... error
Pulling milliner   ... error
Pulling recast     ... error
Pulling solr       ... error
Pulling traefik    ... done
Pulling drupal     ... error
Pulling watchtower ... done
```