### PR TITLE
Fixing local / secrets / install from existing site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,21 +314,21 @@ download-default-certs:
 .PHONY: demo
 .SILENT: demo
 demo:
-	$(MAKE) download-default-certs
-	$(MAKE) docker-compose.yml
-	$(MAKE) pull
+	$(MAKE) download-default-certs ENVIROMENT=demo
+	$(MAKE) docker-compose.yml ENVIROMENT=demo
+	$(MAKE) pull ENVIROMENT=demo
 	mkdir -p $(CURDIR)/codebase
 	docker-compose up -d
-	$(MAKE) update-settings-php
-	$(MAKE) drupal-public-files-import SRC=$(CURDIR)/demo-data/public-files.tgz
-	$(MAKE) drupal-database
-	$(MAKE) drupal-database-import SRC=$(CURDIR)/demo-data/drupal.sql
-	$(MAKE) hydrate
+	$(MAKE) update-settings-php ENVIROMENT=demo
+	$(MAKE) drupal-public-files-import SRC=$(CURDIR)/demo-data/public-files.tgz ENVIROMENT=demo
+	$(MAKE) drupal-database ENVIROMENT=demo
+	$(MAKE) drupal-database-import SRC=$(CURDIR)/demo-data/drupal.sql ENVIROMENT=demo
+	$(MAKE) hydrate ENVIROMENT=demo
 	docker-compose exec -T drupal with-contenv bash -lc 'drush --root /var/www/drupal/web -l $${DRUPAL_DEFAULT_SITE_URL} upwd admin $${DRUPAL_DEFAULT_ACCOUNT_PASSWORD}'
-	$(MAKE) fcrepo-import SRC=$(CURDIR)/demo-data/fcrepo-export.tgz
-	$(MAKE) reindex-fcrepo-metadata
-	$(MAKE) reindex-solr
-	$(MAKE) reindex-triplestore
+	$(MAKE) fcrepo-import SRC=$(CURDIR)/demo-data/fcrepo-export.tgz ENVIROMENT=demo
+	$(MAKE) reindex-fcrepo-metadata ENVIROMENT=demo
+	$(MAKE) reindex-solr ENVIROMENT=demo
+	$(MAKE) reindex-triplestore ENVIROMENT=demo
 	
 
 .PHONY: local
@@ -338,7 +338,7 @@ local:
 	$(MAKE) docker-compose.yml ENVIRONMENT=local
 	$(MAKE) pull ENVIRONMENT=local
 	mkdir -p $(CURDIR)/codebase
-	if [ -z "$(ls -A ./codebase)" ]; then \
+	if [ -z "$$(ls -A $(CURDIR)/codebase)" ]; then \
 		docker container run --rm -v $(CURDIR)/codebase:/home/root islandora/nginx with-contenv bash -lc 'composer create-project drupal/recommended-project:^9.1 /tmp/codebase; mv /tmp/codebase/* /home/root; cd /home/root; composer config minimum-stability dev; composer require islandora/islandora:dev-8.x-1.x; composer require drush/drush:^10.3'; \
 	fi
 	docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -4,18 +4,8 @@
 
 - [Introduction](#introduction)
 - [Requirements](#requirements)
-- [Installation](#installation)
-  - [Configuring the Environment](#configuring-the-environment)
-    - [Changing the host name](#changing-the-host-name)
-    - [Using an IP address](#using-an-ip-address)
-  - [Applying changes](#applying-changes)
-- [Demo Environment](#demo-environment)
-- [Local Environment](#local-environment)
-  - [Create Local Environment from islandora/demo Image](#create-local-environment-from-islandorademo-image)
-    - [From existing Configuration](#from-existing-configuration)
-    - [Manually](#manually)
-  - [Create Local Environment from Existing Site](#create-local-environment-from-existing-site)
-  - [Create Local Environment from Scratch](#create-local-environment-from-scratch)
+- [Getting Started](#getting-started)
+- [Local Development](#local-development)
 - [Custom Environment](#custom-environment)
 - [Secrets](#secrets)
 - [Services](#services)
@@ -42,7 +32,7 @@ that you supply in a `.env` file.  And there are three use cases we're trying to
 
 - **demo** *(Example site for kicking the tires and looking at Islandora)*
 - **local** *(Local development using composer/drush in the codebase folder)*
-- **production** *(An environment safe to run out the wild)*
+- **custom** *(A custom Dockerfile to deploy created from local)*
 
 On top of that, there's a lot of useful commands for managing an Islandora instance, such
 as database import/export and reindexing.
@@ -108,20 +98,28 @@ docker-compose down -v
 
 ## Local Development
 
-Before you go any further, make sure you've set `ENVIRONMENT=local` in  your .env file.
-
 When developing locally, your Drupal site resides in the `codebase` folder and is bind-mounted into your
 Drupal container.  This lets you update code using the IDE of your choice on your host machine, and the
 changes are automatically reflected on the Drupal container.  Simply place any exported Drupal site as
-the `codebase` folder in `isle-dc` and you're good to go.  From there, run
-
-```bash
-make local
-```
+the `codebase` folder in `isle-dc` and you're good to go.
 
 If you don't provide a codebase, you'll be given a vanilla Drupal 9 instance with the Islandora module
 installed and the bare minimum configured to run.  This is useful if you want to build your repository
 from scratch and avoid `islandora_defaults`.
+
+If you've included configuration in your exported site using `drush config:export`, then you'll need
+to set two values in your .env file:
+
+```
+INSTALL_EXISTING_CONFIG=true
+DRUPAL_INSTALL_PROFILE=minimal
+```
+
+In either case, run this command to make a local environment.
+
+```bash
+make local
+```
 
 If you already have a Drupal site but don't know how to export it,
 log into your server, navigate to the Drupal root, and run the following commands:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,6 +21,9 @@ services:
       - ./codebase:/var/www/drupal:delegated
       - drupal-sites-data:/var/www/drupal/web/sites/default/files
       - solr-data:/opt/solr/server/solr
+    environment:
+      DRUPAL_DEFAULT_INSTALL_EXISTING_CONFIG: ${INSTALL_EXISTING_CONFIG}
+      DRUPAL_DEFAULT_PROFILE: ${DRUPAL_INSTALL_PROFILE}
     depends_on:
       # Requires a the very minimum a database.
       - ${DRUPAL_DATABASE_SERVICE}

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -30,6 +30,8 @@ secrets:
     file: "./secrets/MATOMO_DB_PASSWORD"
   MATOMO_USER_PASS:
     file: "./secrets/MATOMO_USER_PASS"
+  TOMCAT_ADMIN_PASSWORD:
+    file: "./secrets/TOMCAT_ADMIN_PASSWORD"
 services:
   activemq:
     secrets:

--- a/sample.env
+++ b/sample.env
@@ -56,7 +56,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=99056a6780c1c41a752f47d5a3599b2be9e5ed65
+TAG=0073ecdd7806fbdee23f674660c15ea0e1ddc561
 
 ###############################################################################
 # Global Environment variables
@@ -65,3 +65,11 @@ TAG=99056a6780c1c41a752f47d5a3599b2be9e5ed65
 DOMAIN=islandora.traefik.me
 DISABLE_SYN=false
 FEDORA_6=true
+
+# If you're just demoing or are starting from scratch, use this.
+INSTALL_EXISTING_CONFIG=false
+DRUPAL_INSTALL_PROFILE=standard
+
+# If you're installing from an existing codebase, uncomment this
+#INSTALL_EXISTING_CONFIG=true
+#DRUPAL_INSTALL_PROFILE=minimal


### PR DESCRIPTION
I've tested this with `make demo`, `make local` with and without a codebase, with and without existing config, with and without secrets, and with Fedora 5 and 6.  Which, when you look at it, is a pretty big matrix :sweat_drops: 

I added some config to make sure `make local` works when you want to install from existing config.  Check the README changes for instructions on that.

This should fix a lot of issues reported by @Tristaan hopefully.