### PR TITLE
No longer use volume for Matomo install

### DIFF
--- a/docker-compose.matomo.yml
+++ b/docker-compose.matomo.yml
@@ -5,15 +5,11 @@ networks:
   gateway:
     external:
       name: gateway
-volumes:
-  matomo-config-data:
 services:
   matomo:
     image: ${REPOSITORY:-islandora}/matomo:${TAG:-latest}
     environment:
       MATOMO_DEFAULT_SITE_HOST: ${DOMAIN}
-    volumes:
-      - matomo-config-data:/var/www/matomo
     depends_on:
       - mariadb
     networks:


### PR DESCRIPTION
Having the code base in a volume makes upgrades and migrations a pain,
additionaly the file copies on initial startup can be really slow on NFS
drives.

Having a volume allows for the dynamic installation of plugins, but then
that is specific to that instance, if you were to run a several stage
environment dev/stage/prod then one would need to manually check that
the plugins exist is each environment. Better would be to extend the
image and pack the plugins in with the installation.

@see matomo-org/docker#57
@see matomo-org/docker#161