### PR TITLE
Passing through REPOSITORY and TAG variables into `make local`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ local:
 	$(MAKE) pull ENVIRONMENT=local
 	mkdir -p $(CURDIR)/codebase
 	if [ -z "$$(ls -A $(CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root islandora/nginx with-contenv bash -lc 'composer create-project drupal/recommended-project:^9.1 /tmp/codebase; mv /tmp/codebase/* /home/root; cd /home/root; composer config minimum-stability dev; composer require islandora/islandora:dev-8.x-1.x; composer require drush/drush:^10.3'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project drupal/recommended-project:^9.1 /tmp/codebase; mv /tmp/codebase/* /home/root; cd /home/root; composer config minimum-stability dev; composer require islandora/islandora:dev-8.x-1.x; composer require drush/drush:^10.3'; \
 	fi
 	docker-compose up -d
 	docker-compose exec -T drupal with-contenv bash -lc 'composer install; chown -R nginx:nginx .'


### PR DESCRIPTION
Potential fix for an issue twice reported on Slack.  `make local` uses `docker run` to fire up an `nginx` container to use composer and php for stuff. We're neglecting to provide a tag, so it's assuming `latest`, which I have delete from Dockerhub.  These changes should force you to use whatever you've set in the env file.

@seth-shaw-unlv can you confirm this fixes the issue? 