### PR TITLE
Adding external volumes for drupal and database

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -21,6 +21,7 @@ services:
       - ./codebase:/var/www/drupal:delegated
       - drupal-sites-data:/var/www/drupal/web/sites/default/files
       - solr-data:/opt/solr/server/solr
+      - /opt/isle-data:/opt/isle-data:delegated
     environment:
       DRUPAL_DEFAULT_INSTALL_EXISTING_CONFIG: ${INSTALL_EXISTING_CONFIG}
       DRUPAL_DEFAULT_PROFILE: ${DRUPAL_INSTALL_PROFILE}

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -11,8 +11,8 @@ services:
   mariadb:
     image: ${REPOSITORY:-islandora}/mariadb:${TAG:-latest}
     volumes:
-      - mariadb-data:/var/lib/mysql
-      - mariadb-files:/var/lib/mysql-files
+      - /opt/isle-db/mysql:/var/lib/mysql:delegated
+      - /opt/isle-db/mysql-files:/var/lib/mysql-files:delegated
     # Allows for access to the database through traefik to support using Drush locally.
     # This should not be used in production.
     #


### PR DESCRIPTION
Currently this pull request will not update the permissions of the created volumes on the host server.
Recommend that those be created separately and the following permissions made:
group: systemd-journal with read/write permission