### PR TITLE
Fixing http/s error with fcrepo allowed external content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ download-default-certs:
 .SILENT: demo
 demo:
 	$(MAKE) download-default-certs ENVIROMENT=demo
-	$(MAKE) docker-compose.yml ENVIROMENT=demo
+	$(MAKE) -B docker-compose.yml ENVIROMENT=demo
 	$(MAKE) pull ENVIROMENT=demo
 	mkdir -p $(CURDIR)/codebase
 	docker-compose up -d
@@ -339,7 +339,7 @@ demo:
 .SILENT: local
 local:
 	$(MAKE) download-default-certs ENVIROMENT=local
-	$(MAKE) docker-compose.yml ENVIRONMENT=local
+	$(MAKE) -B docker-compose.yml ENVIRONMENT=local
 	$(MAKE) pull ENVIRONMENT=local
 	mkdir -p $(CURDIR)/codebase
 	if [ -z "$$(ls -A $(CURDIR)/codebase)" ]; then \

--- a/docker-compose.fcrepo.yml
+++ b/docker-compose.fcrepo.yml
@@ -11,7 +11,8 @@ services:
   fcrepo:
     image: ${REPOSITORY:-islandora}/fcrepo:${TAG:-latest}
     environment:
-      FCREPO_ALLOW_EXTERNAL_DRUPAL: https://${DOMAIN}/
+      FCREPO_ALLOW_EXTERNAL_DRUPALHTTP: http://${DOMAIN}/
+      FCREPO_ALLOW_EXTERNAL_DRUPALHTTPS: https://${DOMAIN}/
       FCREPO_TOMCAT_ADMIN_ROLES: manager-gui,fedoraAdmin
       FCREPO_TOMCAT_ADMIN_USER: admin 
       FCREPO_DISABLE_SYN: ${DISABLE_SYN}

--- a/docker-compose.fcrepo.yml
+++ b/docker-compose.fcrepo.yml
@@ -11,7 +11,7 @@ services:
   fcrepo:
     image: ${REPOSITORY:-islandora}/fcrepo:${TAG:-latest}
     environment:
-      FCREPO_ALLOW_EXTERNAL_DRUPAL: http://${DOMAIN}/
+      FCREPO_ALLOW_EXTERNAL_DRUPAL: https://${DOMAIN}/
       FCREPO_TOMCAT_ADMIN_ROLES: manager-gui,fedoraAdmin
       FCREPO_TOMCAT_ADMIN_USER: admin 
       FCREPO_DISABLE_SYN: ${DISABLE_SYN}

--- a/docker-compose.fcrepo6.yml
+++ b/docker-compose.fcrepo6.yml
@@ -11,7 +11,7 @@ services:
   fcrepo:
     image: ${REPOSITORY:-islandora}/fcrepo6:${TAG:-latest}
     environment:
-      FCREPO_ALLOW_EXTERNAL_DRUPAL: http://${DOMAIN}/
+      FCREPO_ALLOW_EXTERNAL_DRUPAL: https://${DOMAIN}/
       FCREPO_TOMCAT_ADMIN_ROLES: manager-gui,fedoraAdmin
       FCREPO_TOMCAT_ADMIN_USER: admin 
       FCREPO_DISABLE_SYN: ${DISABLE_SYN}

--- a/docker-compose.fcrepo6.yml
+++ b/docker-compose.fcrepo6.yml
@@ -11,7 +11,8 @@ services:
   fcrepo:
     image: ${REPOSITORY:-islandora}/fcrepo6:${TAG:-latest}
     environment:
-      FCREPO_ALLOW_EXTERNAL_DRUPAL: https://${DOMAIN}/
+      FCREPO_ALLOW_EXTERNAL_DRUPALHTTP: http://${DOMAIN}/
+      FCREPO_ALLOW_EXTERNAL_DRUPALHTTPS: https://${DOMAIN}/
       FCREPO_TOMCAT_ADMIN_ROLES: manager-gui,fedoraAdmin
       FCREPO_TOMCAT_ADMIN_USER: admin 
       FCREPO_DISABLE_SYN: ${DISABLE_SYN}


### PR DESCRIPTION
Resolves https://github.com/Islandora/documentation/issues/1861

Requires https://github.com/Islandora-Devops/isle-buildkit/pull/150

### Testing Instructions

- Set `TAG=a5a5884be9650c6f9407ebb314774dd4c4ae3d8a` in your `.env`
- `make -B docker-compose.yml`
- `make demo`
- Make a Repository Item
- Give it an Original File
- Derivatives should have their RDF indexed in Fedora