### PR TITLE
Expose PHP variables to make them easier to adjust

### DIFF
--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -14,6 +14,10 @@ secrets:
     file: "./secrets/CODE_SERVER_PASSWORD"
 services:
   code-server:
+    environment:
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
+      PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}
+      PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
     image: ${REPOSITORY:-islandora}/code-server:${TAG:-latest}
     labels:
       - traefik.enable=true

--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -58,7 +58,11 @@ services:
     depends_on:
       - drupal
   drupal:
-    # Disable traefik for Drupal as code-server will respond to all requests.
+    environment:
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
+      PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}
+      PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
+ # Disable traefik for Drupal as code-server will respond to all requests.
     labels:
       - traefik.enable=false
     volumes:

--- a/docker-compose.drupal.yml
+++ b/docker-compose.drupal.yml
@@ -16,6 +16,9 @@ services:
       DRUPAL_DEFAULT_FCREPO_PORT: 8081
       DRUPAL_DEFAULT_MATOMO_URL: https://${DOMAIN}/matomo/
       DRUPAL_DEFAULT_SITE_URL: http://${DOMAIN} # Make sure this is just http and not https!
+      PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
+      PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}
+      PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
     labels:
       - traefik.enable=true
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-drupal.loadbalancer.server.port=80

--- a/sample.env
+++ b/sample.env
@@ -69,6 +69,11 @@ DOMAIN=islandora.traefik.me
 DISABLE_SYN=false
 FEDORA_6=true
 
+# PHP variables
+PHP_MEMORY_LIMIT=256M
+PHP_POST_MAX_SIZE=128M
+PHP_UPLOAD_MAX_FILESIZE=128M
+
 # If you're just demoing or are starting from scratch, use this.
 INSTALL_EXISTING_CONFIG=false
 DRUPAL_INSTALL_PROFILE=standard


### PR DESCRIPTION
Resolves #170: Adds PHP memory limit and file upload maximum variables to `sample.env` and `docker-compose.drupal.yml` so that they can be easily adjusted. 