### PR TITLE
Watchtower vendor change

### DIFF
--- a/docker-compose.watchtower.yml
+++ b/docker-compose.watchtower.yml
@@ -4,7 +4,7 @@
 version: "3.7"
 services:
   watchtower:
-    image: v2tec/watchtower
+    image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     command: --interval 1 --no-pull


### PR DESCRIPTION
v2tec doesn't have an arm build, so it fails to start on an Apple m1 processor. Switching to the new vendor name appears to work. 

I will be honest though, I do not know how test beyond this simple switch, and that it stays running.