### PR TITLE
Add README note on Docker Compose 2.0 config syntax compatibility .

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,22 @@ as database import/export and reindexing.
 - Docker-CE 19.x+ (*If using Docker Desktop for Windows, any stable release
   *after* 2.2.0.4, or use a 2.2.0.4 with a [patch][Docker for Windows Patch] due
   to a [bug][Docker for Windows Bug]*)
-- Docker-compose version 1.25.x+
+- Docker-compose version 1.25.x+.* Docker is now rolling out a 2.0.x branch, with incompatible config file syntax. 
 - Drush 9.0+
 - Git 2.0+
 - GNU Make 4.0+
+
+* As of August, 2021, Docker Desktop is now shipping with docker-compose 2.0 which has incompatible config file syntax. Until this is addressed, run 
+
+```bash
+docker-compose disable-v2
+```
+
+before running any of the make commands below.
+
+
+See release notes at https://docs.docker.com/compose/cli-command/.
+
 
 ## Getting Started
 


### PR DESCRIPTION
Issue: https://github.com/Islandora/documentation/issues/1892

What does this pull request do?

Add note to README for a workaround to the incompatible Docker Compose file format.