### PR TITLE
Expose PHP max_execution_time variable to make it easier to adjust

### DIFF
--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -18,6 +18,7 @@ services:
       PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
       PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}
       PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
+      PHP_MAX_EXECUTION_TIME: ${PHP_MAX_EXECUTION_TIME}
     restart: ${RESTART_POLICY:-unless-stopped}
     image: ${REPOSITORY:-islandora}/code-server:${TAG:-latest}
     labels:
@@ -67,6 +68,7 @@ services:
       PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
       PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}
       PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
+      PHP_MAX_EXECUTION_TIME: ${PHP_MAX_EXECUTION_TIME}
  # Disable traefik for Drupal as code-server will respond to all requests.
     labels:
       - traefik.enable=false

--- a/docker-compose.drupal.yml
+++ b/docker-compose.drupal.yml
@@ -20,6 +20,7 @@ services:
       PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
       PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}
       PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
+      PHP_MAX_EXECUTION_TIME: ${PHP_MAX_EXECUTION_TIME}
     labels:
       - traefik.enable=true
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-drupal.loadbalancer.server.port=80

--- a/sample.env
+++ b/sample.env
@@ -74,6 +74,7 @@ RESTART_POLICY=unless-stopped
 PHP_MEMORY_LIMIT=256M
 PHP_POST_MAX_SIZE=128M
 PHP_UPLOAD_MAX_FILESIZE=128M
+PHP_MAX_EXECUTION_TIME=30
 
 # If you're just demoing or are starting from scratch, use this.
 INSTALL_EXISTING_CONFIG=false


### PR DESCRIPTION
Just adding an extra PHP variable based on pull request #171. 

The reason for this is that when I try to export my config files via /admin/config/development/configuration/full/export it times out. Increasing the max_execution_time variable was the only way I could find to fix this.