### PR TITLE
Make up & down improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,7 +318,6 @@ demo: generate-secrets
 	$(MAKE) reindex-solr ENVIROMENT=demo
 	$(MAKE) reindex-triplestore ENVIROMENT=demo
 
-
 .PHONY: local
 .SILENT: local
 local: generate-secrets
@@ -343,3 +342,16 @@ clean:
 	-docker-compose down -v
 	sudo rm -fr codebase certs secrets/live/*
 	git clean -xffd .
+
+.PHONY: up
+.SILENT: up
+up:
+	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) local
+	@echo "\n Sleeping for 10 seconds to wait for Drupal to finish building.\n"
+	sleep 10
+	docker-compose exec -T drupal with-contenv bash -lc "for_all_sites update_settings_php"
+
+.PHONY: down
+.SILENT: down
+down:
+	-docker-compose down --remove-orphans

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ clean:
 .PHONY: up
 .SILENT: up
 up:
-	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) local
+	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) demo
 	@echo "\n Sleeping for 10 seconds to wait for Drupal to finish building.\n"
 	sleep 10
 	docker-compose exec -T drupal with-contenv bash -lc "for_all_sites update_settings_php"

--- a/README.md
+++ b/README.md
@@ -166,6 +166,19 @@ following to `docker-compose.env.yml`:
 drupal:
   image: YOUR_CUSTOM_IMAGE
 ```
+## Shutting down and bring back up
+To run a non-destructive shutdown and bring it back up without having to know the docker commands needed. This keeps all of the commands for basic operations within the make commands.
+```shell
+# Shut down isle-dc with losing work.
+make down
+
+# Bring isle-dc back up from where it left off
+make up
+
+# If make hasn't been run this will run make demo 
+
+```
+
 ## Secrets
 
 When running Islandora in the wild, you'll want to use secrets to store sensitive


### PR DESCRIPTION
Improving the developer experience making it easier and more intuitive to use. Bringing the site up and down is a basic function for any docker build. Normally we're using `make` commands to start and build this. 

## What this adds
1. A simple method (within the makefile) to stop the container in a non-destructive way
2. A simple method to bring that site back up. 

Shutting down the container can and usually requires the user to know how this is done within the docker commands and the container specific command to fix the settings php file. 

## To test
From a clean state, from a down state, from an already running state to make sure this doesn't introduce issues.
1. run `make clean` to start from a clean state
2. run `make up`
3. Review if it looks the same as running `make demo`
4. Run `make down` 
5. Verify the system is down and the containers are not running `docker ps -a`
6. Run `make up`  
7. Review if it looks the same as running `make demo`
8. Make a change to something like changing the name of a collection.
9. Run `make down` then `make up`
10. Review that the changes made before still persist. 
11. While its still up run the `make up` command again. This should just speed to the 10 second wait message then after the 10 seconds it will exit without really doing anything.

It should look like this on the final step.
```shell
┌──[~/github/isle-dc]
└─$ make up
Creating network "isle-dc_default" with the default driver
Creating network "gateway" with driver "bridge"
Creating isle-dc_milliner_1   ... done
Creating isle-dc_activemq_1   ... done
Creating isle-dc_mariadb_1    ... done
Creating isle-dc_watchtower_1 ... done
Creating isle-dc_recast_1     ... done
Creating isle-dc_houdini_1    ... done
Creating isle-dc_fits_1       ... done
Creating isle-dc_hypercube_1  ... done
Creating isle-dc_blazegraph_1 ... done
Creating isle-dc_cantaloupe_1 ... done
Creating isle-dc_alpaca_1     ... done
Creating traefik              ... done
Creating isle-dc_solr_1       ... done
Creating isle-dc_homarus_1    ... done
Creating isle-dc_matomo_1     ... done
Creating isle-dc_fcrepo_1     ... done
Creating isle-dc_crayfits_1   ... done
Creating isle-dc_drupal_1     ... done

 Sleeping for 10 seconds to wait for Drupal to finish building.

```