### PR TITLE
Add sudo password warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To get started with a **demo** environment, run:
 ```bash
 make demo
 ```
+⚠️ If prompted during `make up\demo\local\clean` for password, use your computer's password. The build process may need elevated privileges to write or remove files. For other password information see [Secrets](#secrets)
 
 This will pull down images from Dockerhub and generate
 


### PR DESCRIPTION
This is to clarify that a password prompt during build/clean isn't asking for a secret but your system's password. This came up during a conversation with someone that had issues building isle-dc.


I had an alternative description if the one was too short. 

> ⚠️ All passwords generated will be automatically added to the docker containers and can be found under `./secrets/live/`. It's likely you will be prompted to enter in a password. This is your local computer's user account password due to an action that requires elevated privileges. It is likely to happen upon building the containers or when running `make clean`.