### PR TITLE
Adds a fix for missing masonry library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,5 +392,6 @@ LATEST_VERSION := $(shell curl -s https://api.github.com/repos/desandro/masonry/
 ## Fix missing masonry library.
 fix-masonry:
 	@echo "Latest version of masonry library is ${LATEST_VERSION}"
+	docker-compose exec drupal bash -lc "[ -d '/var/www/drupal/web/libraries' ] && exit ; mkdir -p /var/www/drupal/web/libraries ; chmod 755 /var/www/drupal/web/libraries ; chown 1000:nginx /var/www/drupal/web/libraries"
 	docker-compose exec drupal bash -lc "cd /var/www/drupal/web/libraries/ ; [ ! -d '/var/www/drupal/web/libraries/masonry' ] && git clone --quiet --branch ${LATEST_VERSION} https://github.com/desandro/masonry.git || echo Ready"
-	docker-compose exec drupal bash -lc "cd /var/www/drupal/web/libraries/ ; [ -d '/var/www/drupal/web/libraries/masonry' ] && chmod -R 755 /var/www/drupal/web/libraries/masonry"
+	docker-compose exec drupal bash -lc "cd /var/www/drupal/web/libraries/ ; [ -d '/var/www/drupal/web/libraries/masonry' ] && chmod -R 755 /var/www/drupal/web/libraries/masonry ; chown -R 1000:nginx /var/www/drupal/web/libraries/masonry"

--- a/Makefile
+++ b/Makefile
@@ -384,3 +384,13 @@ help:
 		} \
 	} \
 	{lastLine = $$0}' $(MAKEFILE_LIST)
+
+LATEST_VERSION := $(shell curl -s https://api.github.com/repos/desandro/masonry/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/')
+
+.PHONY: fix-masonry
+.SILENT: fix-masonry
+## Fix missing masonry library.
+fix-masonry:
+	@echo "Latest version of masonry library is ${LATEST_VERSION}"
+	docker-compose exec drupal bash -lc "cd /var/www/drupal/web/libraries/ ; [ ! -d '/var/www/drupal/web/libraries/masonry' ] && git clone --quiet --branch ${LATEST_VERSION} https://github.com/desandro/masonry.git || echo Ready"
+	docker-compose exec drupal bash -lc "cd /var/www/drupal/web/libraries/ ; [ -d '/var/www/drupal/web/libraries/masonry' ] && chmod -R 755 /var/www/drupal/web/libraries/masonry"


### PR DESCRIPTION
I'm assuming this is a temporary fix and the solution should permanently be ironed out somewhere else but until someone has time this can substitute.

Issues is that the Masonry library is missing upon a fresh build.

### To replicate error message:
Must have something to trigger an update hook and not already have the library installed. This should work from a clean build.
```shell
$ drush updatedb
```

![Screenshot from 2021-11-18 11-10-34](https://user-images.githubusercontent.com/2738244/142469603-c01ba64f-bfa0-4e75-9588-d6a5a1ae561c.png)

### Then run this to fix it:
```shell
# Comment should show 
$ make help
...
  fix-masonry          Fix missing masonry library. <----

$ make fix-masonry
```

If ran a second time it will recognize the directory is there and skip cloning it down.

### Check the fix worked:
Should have no errors prior to entering "y" to import.
```shell
$ drush updatedb 
```