### PR TITLE
Explain Docker Hub in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@
 ## Introduction
 
 [Docker Compose] project for creating and managing an Islandora 8 instance
-using [Docker] containers from [isle-buildkit](https://github.com/Islandora-Devops/isle-buildkit).
+using [Docker] containers from [Docker Hub](https://hub.docker.com/u/islandora) 
+that were created by [isle-buildkit](https://github.com/Islandora-Devops/isle-buildkit).
 
 In a nutshell, `isle-dc` generates a docker-compose.yml file for you based on configuration
 that you supply in a `.env` file.  And there are three use cases we're trying to accomplish:


### PR DESCRIPTION
sister PR to https://github.com/Islandora-Devops/isle-buildkit/pull/171

Explain that the docker images are pulled from Docker Hub. I think the PR against Isle Buildkit is more important than this one, and I'm not 100% sure if this info needs to be here.  I definitely don't think that a more detailed explanation (i.e. how to trace down to the `image: ` directive) needs to be in this README but might belong in other documentation, like a 'how stuff gets wired together' or 'developing with isle' page in the main docs.

@adam-vessey @noahwsmith  thanks again for the explanation. 