### PR TITLE
added options to sample.env for exposing containers via traefik

### DIFF
--- a/docker-compose.activemq.yml
+++ b/docker-compose.activemq.yml
@@ -14,7 +14,7 @@ services:
       - activemq-data:/opt/activemq/data
     labels:
       # Do not expose in production.
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_ACTIVEMQ:-false}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-activemq.loadbalancer.server.port=8161
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-activemq_http.service=${COMPOSE_PROJECT_NAME-isle-dc}-activemq
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-activemq_http.entrypoints=activemq

--- a/docker-compose.blazegraph.yml
+++ b/docker-compose.blazegraph.yml
@@ -15,7 +15,7 @@ services:
     networks:
       default:
     labels:
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_BLAZEGRAPH:-false}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-blazegraph.loadbalancer.server.port=80
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-blazegraph_http.service=${COMPOSE_PROJECT_NAME-isle-dc}-blazegraph
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-blazegraph_http.entrypoints=blazegraph

--- a/docker-compose.cantaloupe.yml
+++ b/docker-compose.cantaloupe.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - cantaloupe-data:/data
     labels:
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_CANTALOUPE:-true}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-cantaloupe.loadbalancer.server.port=80
       - traefik.http.middlewares.cantaloupe-redirectscheme.redirectscheme.scheme=https
       - traefik.http.middlewares.cantaloupe-redirectscheme.redirectscheme.permanent=true

--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -21,7 +21,7 @@ services:
     restart: ${RESTART_POLICY:-unless-stopped}
     image: ${REPOSITORY:-islandora}/code-server:${TAG:-latest}
     labels:
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_CODE_SERVER:-false}
       # code-server  
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-code-server.loadbalancer.server.port=8443
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-code-server_https.service=${COMPOSE_PROJECT_NAME-isle-dc}-code-server

--- a/docker-compose.drupal.yml
+++ b/docker-compose.drupal.yml
@@ -21,7 +21,7 @@ services:
       PHP_UPLOAD_MAX_FILESIZE: ${PHP_UPLOAD_MAX_FILESIZE}
       PHP_MAX_EXECUTION_TIME: ${PHP_MAX_EXECUTION_TIME}
     labels:
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_DRUPAL:-true}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-drupal.loadbalancer.server.port=80
       - traefik.http.middlewares.drupal-redirectscheme.redirectscheme.scheme=https
       - traefik.http.middlewares.drupal-redirectscheme.redirectscheme.permanent=true

--- a/docker-compose.fcrepo.yml
+++ b/docker-compose.fcrepo.yml
@@ -24,7 +24,7 @@ services:
       default:
     labels:
       # Do not expose in production.
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_FEDORA:-false}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo.loadbalancer.server.port=80
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo_http.service=${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo_http.entrypoints=fcrepo

--- a/docker-compose.fcrepo6.yml
+++ b/docker-compose.fcrepo6.yml
@@ -24,7 +24,7 @@ services:
       default:
     labels:
       # Do not expose in production.
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_FEDORA:-false}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo.loadbalancer.server.port=80
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo_http.service=${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-fcrepo_http.entrypoints=fcrepo

--- a/docker-compose.mariadb.yml
+++ b/docker-compose.mariadb.yml
@@ -20,7 +20,7 @@ services:
     # Since this is not http, but tcp traffic it does does not understand the concept of a "host".
     # so we must dedicate a port to it in traefik, and direct all traffic to this router: HostSNI(`*`).
     labels:
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_MYSQL:-false}
       - traefik.tcp.services.${COMPOSE_PROJECT_NAME-isle-dc}-mysql.loadbalancer.server.port=3306
       - traefik.tcp.routers.${COMPOSE_PROJECT_NAME-isle-dc}-mysql_tcp.service=${COMPOSE_PROJECT_NAME-isle-dc}-mysql
       - traefik.tcp.routers.${COMPOSE_PROJECT_NAME-isle-dc}-mysql_tcp.entrypoints=mysql

--- a/docker-compose.matomo.yml
+++ b/docker-compose.matomo.yml
@@ -20,7 +20,7 @@ services:
       default:
     labels:
       # Do not expose in production over http, setup https.
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_MATOMO:-true}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-matomo.loadbalancer.server.port=80
       - traefik.http.middlewares.${COMPOSE_PROJECT_NAME-isle-dc}-matomo-redirectscheme.redirectscheme.scheme=https
       - traefik.http.middlewares.${COMPOSE_PROJECT_NAME-isle-dc}-matomo-redirectscheme.redirectscheme.permanent=true

--- a/docker-compose.postgresql.yml
+++ b/docker-compose.postgresql.yml
@@ -24,7 +24,7 @@ services:
     # Since this is not http, but tcp traffic it does does not understand the concept of a "host".
     # so we must dedicate a port to it in traefik, and direct all traffic to this router: HostSNI(`*`).
     labels:
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_POSTGRES:-false}
       - traefik.tcp.services.${COMPOSE_PROJECT_NAME-isle-dc}-postgresql.loadbalancer.server.port=5432
       - traefik.tcp.routers.${COMPOSE_PROJECT_NAME-isle-dc}-postgresql_tcp.service=${COMPOSE_PROJECT_NAME-isle-dc}-postgresql
       - traefik.tcp.routers.${COMPOSE_PROJECT_NAME-isle-dc}-postgresql_tcp.entrypoints=postgresql

--- a/docker-compose.solr.yml
+++ b/docker-compose.solr.yml
@@ -15,7 +15,7 @@ services:
       default:
     labels:
       # Do not expose in production.
-      - traefik.enable=true
+      - traefik.enable=${EXPOSE_SOLR:-false}
       - traefik.http.services.${COMPOSE_PROJECT_NAME-isle-dc}-solr.loadbalancer.server.port=8983
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-solr_http.service=${COMPOSE_PROJECT_NAME-isle-dc}-solr
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-solr_http.entrypoints=solr

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -20,9 +20,9 @@ services:
     # Do not set `api.insecure`, `api.dashboard`, `api.debug` to `true` in production.
     # Also do not expose database 3306/5432, as an entry point.
     command: >-
-      --api.insecure=true
-      --api.dashboard=true
-      --api.debug=true
+      --api.insecure=${EXPOSE_TRAEFIK_DASHBOARD:-false}
+      --api.dashboard=${EXPOSE_TRAEFIK_DASHBOARD:-false}
+      --api.debug=${EXPOSE_TRAEFIK_DASHBOARD:-false}
       --entryPoints.http.address=:80
       --entryPoints.https.address=:443
       --entryPoints.mysql.address=:3306
@@ -41,14 +41,14 @@ services:
       - 80:80       # drupal, cantaloupe, matomo
       - 443:443     # https for ^^^
       # Don't do any of these in production
-      - 3306:3306   # mysql
-      - 5432:5432   # postgres
-      - 8080:8080   # traefik admin dashboard - helpful for debugging
-      - 8081:8081   # fedora 
-      - 8082:8082   # blazegraph      
-      - 8161:8161   # activemq
-      - 8983:8983   # solr
-      - 8443:8443   # code-server
+      - ${MYSQL_PORT:-3306}:3306   # mysql
+      - ${POSTGRES_PORT:-5432}:5432   # postgres
+      - ${TRAEFIK_DASHBOARD_PORT:-8080}:8080   # traefik admin dashboard - helpful for debugging
+      - ${FEDORA_PORT:-8081}:8081   # fedora
+      - ${BLAZEGRAPH_PORT:-8082}:8082   # blazegraph
+      - ${ACTIVEMQ_PORT:-8161}:8161   # activemq
+      - ${SOLR_PORT:-8983}:8983   # solr
+      - ${CODE_SERVER_PORT:-8443}:8443   # code-server
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./tls.yml:/etc/traefik/tls.yml

--- a/sample.env
+++ b/sample.env
@@ -17,6 +17,7 @@ USE_SECRETS=false
 ###############################################################################
 # Environment variables specific to composer.
 ###############################################################################
+
 COMPOSE_HTTP_TIMEOUT=480
 
 # Also used for naming services in traefik as well as defining network alias and urls.
@@ -31,7 +32,7 @@ DOCKER_BUILDKIT=1
 # Dockerfile to use when building the custom project.
 PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 
-# Includes `traefik` as a service, if false assume we are sharing a traefik 
+# Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.
 INCLUDE_TRAEFIK_SERVICE=true
 
@@ -60,6 +61,51 @@ REPOSITORY=islandora
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
 TAG=1.0.0-alpha-6
+
+###############################################################################
+# Exposed Containers & Ports
+###############################################################################
+
+# Expose Cantaloupe at ${DOMAIN}/cantaloupe
+EXPOSE_CANTALOUPE=true
+
+# Expose Matomo at ${DOMAIN}/matomo
+EXPOSE_MATOMO=true
+
+# Expose Drupal at ${DOMAIN}
+EXPOSE_DRUPAL=true
+
+# Expose MySQL over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_MYSQL=false
+MYSQL_PORT=3306
+
+# Expose Postgres over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_POSTGRES=false
+POSTGRES_PORT=5432
+
+# Expose the Traefik dashboard over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_TRAEFIK_DASHBOARD=false
+TRAEFIK_DASHBOARD_PORT=8080
+
+# Expose Fedora over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_FEDORA=false
+FEDORA_PORT=8081
+
+# Expose Blazegraph over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_BLAZEGRAPH=false
+BLAZEGRAPH_PORT=8082
+
+# Expose Activemq over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_ACTIVEMQ=false
+ACTIVEMQ_PORT=8161
+
+# Expose SOLR over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_SOLR=false
+SOLR_PORT=8983
+
+# Expose Code Server over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+EXPOSE_CODE_SERVER=false
+CODE_SERVER_PORT=8443
 
 ###############################################################################
 # Global Environment variables


### PR DESCRIPTION
As suggested in [issue 1667](https://github.com/Islandora/documentation/issues/1667) I have added variables to sample.env for each of the services that have traefik.enable labels in their yml files. I have set the defaults to false for everything except Drupal, Matomo, and Canteloupe, since those others should not be exposed in production.

I also added variables for the ports to use when exposing those other containers, with the defaults being the same ports we were using before. For example if you want Solr to run on a port other than 8983 you can change it in your .env and traefik will expose it on the port you supply in the variable.

I also added a variable for the Traefik dashboard which determines api.insecure, api.dashboard, and api.debug all in one.