### PR TITLE
189 code server fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ DATABASE_SERVICES := $(sort $(DATABASE_SERVICES))
 # The services to be run (order is important), as services can override one
 # another. Traefik must be last if included as otherwise its network
 # definition for `gateway` will be overriden.
-SERVICES := $(REQUIRED_SERIVCES) $(FCREPO_SERVICE) $(WATCHTOWER_SERVICE) $(ETCD_SERVICE) $(DATABASE_SERVICES) $(ENVIRONMENT) $(TRAEFIK_SERVICE) $(SECRETS) $(CODE_SERVER_SERVICE)
+SERVICES := $(REQUIRED_SERIVCES) $(FCREPO_SERVICE) $(WATCHTOWER_SERVICE) $(ETCD_SERVICE) $(DATABASE_SERVICES) $(ENVIRONMENT) $(SECRETS) $(CODE_SERVER_SERVICE) $(TRAEFIK_SERVICE)
 
 default: download-default-certs docker-compose.yml pull
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export
 EXTERNAL_SERVICES := etcd watchtower traefik
 
 # The minimal set of docker-compose files required to be able to run anything.
-REQUIRED_SERIVCES ?= activemq alpaca blazegraph cantaloupe crayfish crayfits drupal mariadb matomo solr
+REQUIRED_SERVICES ?= activemq alpaca blazegraph cantaloupe crayfish crayfits drupal mariadb matomo solr
 
 ifeq ($(USE_SECRETS), true)
 	SECRETS := secrets
@@ -74,7 +74,7 @@ DATABASE_SERVICES := $(sort $(DATABASE_SERVICES))
 # The services to be run (order is important), as services can override one
 # another. Traefik must be last if included as otherwise its network
 # definition for `gateway` will be overriden.
-SERVICES := $(REQUIRED_SERIVCES) $(FCREPO_SERVICE) $(WATCHTOWER_SERVICE) $(ETCD_SERVICE) $(DATABASE_SERVICES) $(ENVIRONMENT) $(SECRETS) $(CODE_SERVER_SERVICE) $(TRAEFIK_SERVICE)
+SERVICES := $(REQUIRED_SERVICES) $(FCREPO_SERVICE) $(WATCHTOWER_SERVICE) $(ETCD_SERVICE) $(DATABASE_SERVICES) $(ENVIRONMENT) $(SECRETS) $(CODE_SERVER_SERVICE) $(TRAEFIK_SERVICE)
 
 default: download-default-certs docker-compose.yml pull
 

--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -8,9 +8,6 @@ networks:
     internal: true
   gateway:
     external: true
-secrets:
-  CODE_SERVER_PASSWORD:
-    file: "./secrets/CODE_SERVER_PASSWORD"
 services:
   code-server:
     environment:
@@ -40,8 +37,6 @@ services:
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.entrypoints=https
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.rule=Host(`${DOMAIN}`)
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.tls=true
-    secrets:
-      - CODE_SERVER_PASSWORD
     volumes:
       # Mount and serve contents of Drupal site.
       - type: volume

--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -37,6 +37,8 @@ services:
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.entrypoints=https
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.rule=Host(`${DOMAIN}`)
       - traefik.http.routers.${COMPOSE_PROJECT_NAME-isle-dc}-drupal_https.tls=true
+    secrets:
+      - CODE_SERVER_PASSWORD
     volumes:
       # Mount and serve contents of Drupal site.
       - type: volume

--- a/docker-compose.code-server.yml
+++ b/docker-compose.code-server.yml
@@ -8,6 +8,9 @@ networks:
     internal: true
   gateway:
     external: true
+secrets:
+  CODE_SERVER_PASSWORD:
+    file: "./secrets/live/CODE_SERVER_PASSWORD"
 services:
   code-server:
     environment:

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -8,8 +8,6 @@ secrets:
     file: "./secrets/live/ALPACA_ACTIVEMQ_PASSWORD"
   ALPACA_KARAF_ADMIN_PASSWORD:
     file: "./secrets/live/ALPACA_KARAF_ADMIN_PASSWORD"
-  CODE_SERVER_PASSWORD:
-    file: "./secrets/live/CODE_SERVER_PASSWORD"
   DB_ROOT_PASSWORD:
     file: "./secrets/live/DB_ROOT_PASSWORD"
   DRUPAL_DEFAULT_ACCOUNT_PASSWORD:

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -46,9 +46,6 @@ services:
   cantaloupe:
     secrets:
       - TOMCAT_ADMIN_PASSWORD
-  code-server:
-    secrets:
-      - CODE_SERVER_PASSWORD
   drupal:
     secrets:
       - DB_ROOT_PASSWORD

--- a/docker-compose.secrets.yml
+++ b/docker-compose.secrets.yml
@@ -8,6 +8,8 @@ secrets:
     file: "./secrets/live/ALPACA_ACTIVEMQ_PASSWORD"
   ALPACA_KARAF_ADMIN_PASSWORD:
     file: "./secrets/live/ALPACA_KARAF_ADMIN_PASSWORD"
+  CODE_SERVER_PASSWORD:
+    file: "./secrets/live/CODE_SERVER_PASSWORD"
   DB_ROOT_PASSWORD:
     file: "./secrets/live/DB_ROOT_PASSWORD"
   DRUPAL_DEFAULT_ACCOUNT_PASSWORD:
@@ -44,6 +46,9 @@ services:
   cantaloupe:
     secrets:
       - TOMCAT_ADMIN_PASSWORD
+  code-server:
+    secrets:
+      - CODE_SERVER_PASSWORD
   drupal:
     secrets:
       - DB_ROOT_PASSWORD


### PR DESCRIPTION
Fix for issue https://github.com/Islandora-Devops/isle-dc/issues/189
Code server yml had the wrong path to the secret file so I updated it to include liv/ in the path. 

I also moved the path variable into the secrets.yml file so that it is with the rest of the secret paths in case they need to be changed again in the future.

There was also an issue where code server was listed as a service after traefik in the makefile which caused the gateway network to be overwritten when code server was included as a service. I moved traefik to the end of this list to stop that from happening.

Lastly, I fixed a typo in the makefile where services was spelled serivces