### PR TITLE
Draft - Adds admin theme and menu bar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,11 @@ demo: generate-secrets
 	$(MAKE) reindex-fcrepo-metadata ENVIROMENT=demo
 	$(MAKE) reindex-solr ENVIROMENT=demo
 	$(MAKE) reindex-triplestore ENVIROMENT=demo
+	docker-compose exec -T drupal with-contenv bash -lc "composer require 'drupal/adminimal_theme:^1.6' --prefer-dist --optimize-autoloader -W"
+	docker-compose exec -T drupal with-contenv bash -lc 'drush theme:enable adminimal_theme'
+	docker-compose exec -T drupal with-contenv bash -lc 'drush config-set system.theme admin adminimal_theme -y'
+	docker-compose exec -T drupal with-contenv bash -lc "composer require 'drupal/adminimal_admin_toolbar:^1.11' --prefer-dist --optimize-autoloader -W"
+	docker-compose exec -T drupal with-contenv bash -lc 'drush pm:enable -y adminimal_admin_toolbar'
 
 .PHONY: local
 .SILENT: local


### PR DESCRIPTION
Only for "demo" did I add the admin theme improvement. Basically it sets the admin theme to adminimal and adds the adminimal menu so the menus have hover action. This should make the demo experience more user friendly. 

## To test
- Look at any /admin page and try to hover over the menus.
- Pull in the changes and the admin theme will have changed
- Go to to themes and adminimal should be enabled and set to admin default but not the overall default
- Hovering over the menus should now show the contents within the menus 