### PR TITLE
Ensure drupal settings are writable to fix non-bootable container.

### DIFF
--- a/rootfs/etc/cont-init.d/04-custom-setup.sh
+++ b/rootfs/etc/cont-init.d/04-custom-setup.sh
@@ -9,7 +9,9 @@ function main {
     create_database "${site}"
     # Needs to be set to do an install from existing configuration.
     drush islandora:settings:create-settings-if-missing
+    local previous_owner_group=$(allow_settings_modifications ${site})
     drush islandora:settings:set-config-sync-directory "${DRUPAL_DEFAULT_CONFIGDIR}"
+    restore_settings_ownership ${site} ${previous_owner_group}
     install_site "${site}"
     # Settings like the hash / flystem can be affected by environment variables at runtime.
     update_settings_php "${site}"

--- a/sample.env
+++ b/sample.env
@@ -59,7 +59,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=1.0.0-alpha-6
+TAG=1.0.0-alpha-11
 
 ###############################################################################
 # Global Environment variables


### PR DESCRIPTION
I am developing an image based on isle-dc and am hitting an issue starting up the drupal container. 

Basically the container can't write to settings.php, so it aborts startup.  This is tricky to fix; you can't easily investigate by opening a shell in the container, because the container only runs for a few seconds before dying.

This PR ensures writability and restores ownership afterwards, using functions refactored in this PR: https://github.com/Islandora-Devops/isle-buildkit/pull/179

Log output from the non-booting container:

drupal_1      | mysqld is alive
drupal_1      | Credentials are valid
drupal_1      | 
drupal_1      | In Filesystem.php line 202:
drupal_1      |                                                                           
drupal_1      |   Failed to chmod file "/var/www/drupal/web/sites/default/settings.php".  
drupal_1      |                                                                           
drupal_1      | 
drupal_1      | islandora:settings:set-config-sync-directory [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-d|--debug] [-y|--yes] [--no] [--remote-host REMOTE-HOST] [--remote-user REMOTE-USER] [-r|--root ROOT] [-l|--uri URI] [--simulate] [--pipe] [-D|--define DEFINE] [--druplicon] [--xh-link XH-LINK] [--notify [NOTIFY]] [--] <command> <path>
drupal_1      | 
drupal_1      | [cont-init.d] 04-custom-setup.sh: exited 1.
drupal_1      | [cont-finish.d] executing container finish scripts...
drupal_1      | [cont-finish.d] done.
drupal_1      | [s6-finish] waiting for services.
drupal_1      | [s6-finish] sending all processes the TERM signal.
drupal_1      | [s6-finish] sending all processes the KILL signal and exiting.
