### PR TITLE
Add some more docs on code-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,11 @@ The code-server service can be disabled/enabled via the
 INCLUDE_CODE_SERVER_SERVICE=true
 ```
 
+* Run `make local`, `make up`, or `make demo` to build the containers and local file system(s).
+* Then modify the `.env` file.
+* Then `make up` to fetch the builds.
+It will then report it created the **code-server** and recreated **traefik** and **drupal** containers.
+
 By default this will accessible at
 [https://islandora.traefik.me:8443/](https://islandora.traefik.me:8443/).
 


### PR DESCRIPTION
Running with code-server isn't clear on how to properly set up. The code-server needs the file system to already be running before it starts. This add the instructions for it.
