### PR TITLE
Add solr core reload/optimize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ solr-cores:
 .PHONY: solr-reload-cores
 .SILENT: solr-reload-cores
 solr-reload-cores:
-	curl $(shell echo "http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/admin/cores?action=RELOAD\&core=ISLANDORA")
-	curl $(shell echo "http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/ISLANDORA/update?optimize=true")
+	curl $(shell grep -Fxq "EXPOSE_SOLR=true" .env && echo "http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/admin/cores?action=RELOAD\&core=ISLANDORA")
+	curl $(shell grep -Fxq "EXPOSE_SOLR=true" .env && echo "http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/ISLANDORA/update?optimize=true")
 	echo "Can be verified at http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/#/~cores/ISLANDORA"
 
 # Creates namespaces in Blazegraph according to the environment variables.

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,14 @@ run-islandora-migrations:
 solr-cores:
 	docker-compose exec -T drupal with-contenv bash -lc "for_all_sites create_solr_core_with_default_config"
 
+# Reloads solr-cores with current live configurations and then optimizes it. This assumes the solr-core is named ISLANDORA.
+.PHONY: solr-reload-cores
+.SILENT: solr-reload-cores
+solr-reload-cores:
+	curl $(shell echo "http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/admin/cores?action=RELOAD\&core=ISLANDORA")
+	curl $(shell echo "http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/ISLANDORA/update?optimize=true")
+	echo "Can be verified at http://$(shell docker inspect -f "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}" $(shell docker ps --format "{{.Names}}" | grep solr)):8983/solr/#/~cores/ISLANDORA"
+
 # Creates namespaces in Blazegraph according to the environment variables.
 .PHONY: namespaces
 .SILENT: namespaces


### PR DESCRIPTION
The `make solr-cores` command "Creates solr-cores according to the environment variables.". This new command `solr-reload-cores` reloads the solr core with current live configurations and then optimizes it. This allows people to reload and optimize from the terminal quickly.

## To test
Before running
![Before](https://user-images.githubusercontent.com/2738244/151240490-0f11554b-d94a-447a-b80a-a51d683a8e31.png)

Then run `make solr-reload-cores` 

After running command
![After running](https://user-images.githubusercontent.com/2738244/151240550-50b52b52-80fb-434f-bcb9-be6981d17f64.png)

```shell
$ make solr-reload-cores 
{
  "responseHeader":{
    "status":0,
    "QTime":243}}
{
  "responseHeader":{
    "status":0,
    "QTime":2}}
Can be verified at http://172.22.0.3:8983/solr/#/~cores/ISLANDORA
```