### PR TITLE
Solr error should not be fatal

### DIFF
--- a/build/rootfs/etc/cont-init.d/04-custom-setup.sh
+++ b/build/rootfs/etc/cont-init.d/04-custom-setup.sh
@@ -24,7 +24,8 @@ function main {
     # to be up and running before they can complete.
     wait_for_required_services "${site}"
     # Create missing solr cores.
-    create_solr_core_with_default_config "${site}"
+    create_solr_core_with_default_config "${site}" || echo -e "\n\nERROR: SOLR was not initialized. Check the logs above for more details.\n\n"
+
     # Create namespace assumed one per site.
     create_blazegraph_namespace_with_default_properties "${site}"
     # Need to run migration to get expected default content, now that our required services are running.


### PR DESCRIPTION
This fixes a difficult usability issue if SOLR cannot be initialized.

Currently, a failure to initialize SOLR results in the container aborting.  In my case, the solution required me to disable some conflicting SOLR request handlers via Drupal's UI, in order for Drupal to be able to generate config.zip.  But this was impossible to do until I could get the container started.  A difficult chicken-and-egg situation which is not easy to recover from. 

I think it is better to flag the SOLR error clearly (hence this PR as well as https://github.com/Islandora-Devops/isle-buildkit/pull/182) but allow the container to start so that Drupal is available.

This PR shows some earlier commits on my fork (but no diffs from them) because they were merged.  Ugly, but I don't know how to clean this up short of deleting my fork entirely and re-creating.  Maybe it's possible to squash when merging?  