### PR TITLE
Update comment about exposing Fedora

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -87,7 +87,7 @@ POSTGRES_PORT=5432
 EXPOSE_TRAEFIK_DASHBOARD=false
 TRAEFIK_DASHBOARD_PORT=8080
 
-# Expose Fedora over the given port - DO NOT EXPOSE THIS IN PRODUCTION
+# Expose Fedora over the given port - Necessary for Canteloupe
 EXPOSE_FEDORA=true
 FEDORA_PORT=8081
 


### PR DESCRIPTION
Per https://github.com/Islandora-Devops/isle-dc/commit/a6f0aa186555ca22d176bf829bf7eb6701b251df fedora needs to be exposed, so we should remove the comment saying not to expose in production