### PR TITLE
Changes to README.md to update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,12 @@ as database import/export and reindexing.
 
 ## Requirements
 
-- Composer 1.10+
 - Desktop / laptop / VM (*Docker must have sufficient resources to run GNU Make*)
-- Docker-CE 19.x+ (*If using Docker Desktop for Windows, any stable release
-  *after* 2.2.0.4, or use a 2.2.0.4 with a [patch][Docker for Windows Patch] due
-  to a [bug][Docker for Windows Bug]*)
-- Docker-compose version 1.25.x+.* Docker is now rolling out a 2.0.x branch, with incompatible config file syntax. 
+- Docker-CE 19.x+
+- Docker-compose version 1.25.x+ 
 - Git 2.0+
 - GNU Make 4.0+
-
-* As of August, 2021, Docker Desktop is now shipping with docker-compose 2.0 which has incompatible config file syntax. Until this is addressed, run 
-
-```bash
-docker-compose disable-v2
-```
+- At least 8GB of RAM (ideally 16GB)
 
 before running any of the make commands below.
 


### PR DESCRIPTION
Removed requirements from README that are now obsolete and added RAM requirement.

Removed requirements:
- Composer 
- mentions of needing to disable docker-compose v2 functionality

Added requirement: 
- At least 8GB of RAM (ideally 16GB)

Alternatively we could have this requirements section in the README just point to this page... 

https://islandora.github.io/documentation/installation/docker-prereq/ 

so we only have to maintain one of these requirements sections, or just have a link to github.io AND make the github.io page just have more verbose requirement details. 