### PR TITLE
Update to sample.env to change defaults

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -12,7 +12,7 @@ ENVIRONMENT=demo
 
 # Enable this to generate a docker-compose file that uses secrets.
 # If you're running staging, CI, or production, set to true.
-USE_SECRETS=false
+USE_SECRETS=true
 
 ###############################################################################
 # Environment variables specific to composer.
@@ -37,7 +37,7 @@ PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 INCLUDE_TRAEFIK_SERVICE=true
 
 # Includes `watchtower` as a service.
-INCLUDE_WATCHTOWER_SERVICE=true
+INCLUDE_WATCHTOWER_SERVICE=false
 
 # Includes `etcd` as a service.
 INCLUDE_ETCD_SERVICE=false


### PR DESCRIPTION
In production, USE_SECRETS should be true and INCLUDE_WATCHTOWER_SERVICE should be false. We should change the defaults so that people need to opt out of secrets and opt in to watchtower.