### PR TITLE
Expose everything including the kitchen sink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,44 @@ local-install-profile: generate-secrets
 initial_content:
 	curl -u admin:$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) -H "Content-Type: application/json" -d "@demo-data/homepage.json" https://${DOMAIN}/node?_format=json
 	curl -u admin:$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) -H "Content-Type: application/json" -d "@demo-data/browse-collections.json" https://${DOMAIN}/node?_format=json
+.PHONY: kitchen_sink
+.SILENT: kitchen_sink
+## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, CODE SERVER. NOT FOR PRODUCTION!!!
+kitchen_sink:
+	echo 'Exposing everything including the kitchen sink...'
+ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
+	$(MAKE) down
+	sed --in-place='' 's/EXPOSE_CANTALOUPE=false/EXPOSE_CANTALOUPE=true/g' .env
+	sed --in-place='' 's/EXPOSE_MATOMO=false/EXPOSE_MATOMO=true/g' .env
+	sed --in-place='' 's/EXPOSE_DRUPAL=false/EXPOSE_DRUPAL=true/g' .env
+	sed --in-place='' 's/EXPOSE_MYSQL=false/EXPOSE_MYSQL=true/g' .env
+	sed --in-place='' 's/EXPOSE_POSTGRES=false/EXPOSE_POSTGRES=true/g' .env
+	sed --in-place='' 's/EXPOSE_TRAEFIK_DASHBOARD=false/EXPOSE_TRAEFIK_DASHBOARD=true/g' .env
+	sed --in-place='' 's/EXPOSE_FEDORA=false/EXPOSE_FEDORA=true/g' .env
+	sed --in-place='' 's/EXPOSE_BLAZEGRAPH=false/EXPOSE_BLAZEGRAPH=true/g' .env
+	sed --in-place='' 's/EXPOSE_ACTIVEMQ=false/EXPOSE_ACTIVEMQ=true/g' .env
+	sed --in-place='' 's/EXPOSE_SOLR=false/EXPOSE_SOLR=true/g' .env
+	sed --in-place='' 's/EXPOSE_CODE_SERVER=false/EXPOSE_CODE_SERVER=true/g' .env
+	sed --in-place='' 's/INCLUDE_CODE_SERVER_SERVICE=false/INCLUDE_CODE_SERVER_SERVICE=true/g' .env
+	$(MAKE) docker-compose.yml
+	$(MAKE) build
+	$(MAKE) up
+	echo "Complete"
+	echo "You can now access the following endpoints:"
+	echo "Drupal:                               https://$(DOMAIN)"
+	echo "Traefik:                              http://$(DOMAIN):8080/dashboard/#/"
+	echo "Fedora:                               http://$(DOMAIN):8081/fcrepo/rest"
+	echo "Blazegraph:                           http://$(DOMAIN):8082/bigdata/#splash"
+	echo "Activemq:                             http://$(DOMAIN):8161"
+	echo "Solr:                                 http://$(DOMAIN):8983/solr/#/"
+	echo "Cantaloupe:                           https://$(DOMAIN)/cantaloupe"
+	echo "Matomo:                               https://$(DOMAIN)/matomo/"
+	echo "Code Server (Code Editor in Browser): https://$(DOMAIN):8443/"
+else
+	echo ""
+	echo "Problem: Run this after you've run one of the make commands to build isle-dc (up, demo, local, etc.). Exiting..."
+endif
+
 
 # Destroys everything beware!
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -452,43 +452,6 @@ local-install-profile: generate-secrets
 initial_content:
 	curl -u admin:$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) -H "Content-Type: application/json" -d "@demo-data/homepage.json" https://${DOMAIN}/node?_format=json
 	curl -u admin:$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) -H "Content-Type: application/json" -d "@demo-data/browse-collections.json" https://${DOMAIN}/node?_format=json
-.PHONY: kitchen_sink
-.SILENT: kitchen_sink
-## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, except CODE SERVER. NOT FOR PRODUCTION!!!
-kitchen_sink:
-	echo 'Exposing everything including the kitchen sink...'
-ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
-	$(MAKE) down
-	sed --in-place='' 's/EXPOSE_CANTALOUPE=false/EXPOSE_CANTALOUPE=true/g' .env
-	sed --in-place='' 's/EXPOSE_MATOMO=false/EXPOSE_MATOMO=true/g' .env
-	sed --in-place='' 's/EXPOSE_DRUPAL=false/EXPOSE_DRUPAL=true/g' .env
-	sed --in-place='' 's/EXPOSE_MYSQL=false/EXPOSE_MYSQL=true/g' .env
-	sed --in-place='' 's/EXPOSE_POSTGRES=false/EXPOSE_POSTGRES=true/g' .env
-	sed --in-place='' 's/EXPOSE_TRAEFIK_DASHBOARD=false/EXPOSE_TRAEFIK_DASHBOARD=true/g' .env
-	sed --in-place='' 's/EXPOSE_FEDORA=false/EXPOSE_FEDORA=true/g' .env
-	sed --in-place='' 's/EXPOSE_BLAZEGRAPH=false/EXPOSE_BLAZEGRAPH=true/g' .env
-	sed --in-place='' 's/EXPOSE_ACTIVEMQ=false/EXPOSE_ACTIVEMQ=true/g' .env
-	sed --in-place='' 's/EXPOSE_SOLR=false/EXPOSE_SOLR=true/g' .env
-	$(MAKE) build
-	$(MAKE) pull ENVIRONMENT=$(ENVIRONMENT)
-	$(MAKE) up
-	$(MAKE) hydrate ENVIRONMENT=$(ENVIRONMENT)
-	$(MAKE) reindex-solr ENVIRONMENT=$(ENVIRONMENT)
-	echo "Complete"
-	echo "You can now access the following endpoints:"
-	echo "Drupal:                               https://$(DOMAIN)"
-	echo "Traefik:                              http://$(DOMAIN):8080/dashboard/#/"
-	echo "Fedora:                               http://$(DOMAIN):8081/fcrepo/rest"
-	echo "Blazegraph:                           http://$(DOMAIN):8082/bigdata/#splash"
-	echo "Activemq:                             http://$(DOMAIN):8161"
-	echo "Solr:                                 http://$(DOMAIN):8983/solr/#/"
-	echo "Cantaloupe:                           https://$(DOMAIN)/cantaloupe"
-	echo "Matomo:                               https://$(DOMAIN)/matomo/"
-else
-	echo ""
-	echo "Problem: Run this after you've run one of the make commands to build isle-dc (up, demo, local, etc.). Exiting..."
-endif
-
 
 # Destroys everything beware!
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -439,7 +439,7 @@ endif
 # Destroys everything beware!
 .PHONY: kitchen_sink
 .SILENT: kitchen_sink
-## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, CODE SERVER. NOT FOR PRODUCTION!!!
+## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, except CODE SERVER. NOT FOR PRODUCTION!!!
 kitchen_sink:
 	echo 'Exposing everything including the kitchen sink...'
 ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
@@ -454,11 +454,11 @@ ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
 	sed --in-place='' 's/EXPOSE_BLAZEGRAPH=false/EXPOSE_BLAZEGRAPH=true/g' .env
 	sed --in-place='' 's/EXPOSE_ACTIVEMQ=false/EXPOSE_ACTIVEMQ=true/g' .env
 	sed --in-place='' 's/EXPOSE_SOLR=false/EXPOSE_SOLR=true/g' .env
-	sed --in-place='' 's/EXPOSE_CODE_SERVER=false/EXPOSE_CODE_SERVER=true/g' .env
-	sed --in-place='' 's/INCLUDE_CODE_SERVER_SERVICE=false/INCLUDE_CODE_SERVER_SERVICE=true/g' .env
-	$(MAKE) docker-compose.yml
 	$(MAKE) build
+	$(MAKE) pull ENVIRONMENT=$(ENVIRONMENT)
 	$(MAKE) up
+	$(MAKE) hydrate ENVIRONMENT=$(ENVIRONMENT)
+	$(MAKE) reindex-solr ENVIRONMENT=$(ENVIRONMENT)
 	echo "Complete"
 	echo "You can now access the following endpoints:"
 	echo "Drupal:                               https://$(DOMAIN)"
@@ -469,7 +469,6 @@ ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
 	echo "Solr:                                 http://$(DOMAIN):8983/solr/#/"
 	echo "Cantaloupe:                           https://$(DOMAIN)/cantaloupe"
 	echo "Matomo:                               https://$(DOMAIN)/matomo/"
-	echo "Code Server (Code Editor in Browser): https://$(DOMAIN):8443/"
 else
 	echo ""
 	echo "Problem: Run this after you've run one of the make commands to build isle-dc (up, demo, local, etc.). Exiting..."

--- a/Makefile
+++ b/Makefile
@@ -437,6 +437,44 @@ endif
 
 
 # Destroys everything beware!
+.PHONY: kitchen_sink
+.SILENT: kitchen_sink
+## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, CODE SERVER. NOT FOR PRODUCTION!!!
+kitchen_sink:
+	echo 'Exposing everything including the kitchen sink...'
+ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
+	$(MAKE) down
+	sed --in-place='' 's/EXPOSE_CANTALOUPE=false/EXPOSE_CANTALOUPE=true/g' .env
+	sed --in-place='' 's/EXPOSE_MATOMO=false/EXPOSE_MATOMO=true/g' .env
+	sed --in-place='' 's/EXPOSE_DRUPAL=false/EXPOSE_DRUPAL=true/g' .env
+	sed --in-place='' 's/EXPOSE_MYSQL=false/EXPOSE_MYSQL=true/g' .env
+	sed --in-place='' 's/EXPOSE_POSTGRES=false/EXPOSE_POSTGRES=true/g' .env
+	sed --in-place='' 's/EXPOSE_TRAEFIK_DASHBOARD=false/EXPOSE_TRAEFIK_DASHBOARD=true/g' .env
+	sed --in-place='' 's/EXPOSE_FEDORA=false/EXPOSE_FEDORA=true/g' .env
+	sed --in-place='' 's/EXPOSE_BLAZEGRAPH=false/EXPOSE_BLAZEGRAPH=true/g' .env
+	sed --in-place='' 's/EXPOSE_ACTIVEMQ=false/EXPOSE_ACTIVEMQ=true/g' .env
+	sed --in-place='' 's/EXPOSE_SOLR=false/EXPOSE_SOLR=true/g' .env
+	sed --in-place='' 's/EXPOSE_CODE_SERVER=false/EXPOSE_CODE_SERVER=true/g' .env
+	sed --in-place='' 's/INCLUDE_CODE_SERVER_SERVICE=false/INCLUDE_CODE_SERVER_SERVICE=true/g' .env
+	$(MAKE) docker-compose.yml
+	$(MAKE) build
+	$(MAKE) up
+	echo "Complete"
+	echo "You can now access the following endpoints:"
+	echo "Drupal:                               https://$(DOMAIN)"
+	echo "Traefik:                              http://$(DOMAIN):8080/dashboard/#/"
+	echo "Fedora:                               http://$(DOMAIN):8081/fcrepo/rest"
+	echo "Blazegraph:                           http://$(DOMAIN):8082/bigdata/#splash"
+	echo "Activemq:                             http://$(DOMAIN):8161"
+	echo "Solr:                                 http://$(DOMAIN):8983/solr/#/"
+	echo "Cantaloupe:                           https://$(DOMAIN)/cantaloupe"
+	echo "Matomo:                               https://$(DOMAIN)/matomo/"
+	echo "Code Server (Code Editor in Browser): https://$(DOMAIN):8443/"
+else
+	echo ""
+	echo "Problem: Run this after you've run one of the make commands to build isle-dc (up, demo, local, etc.). Exiting..."
+endif
+
 .PHONY: clean
 .SILENT: clean
 ## Destroys everything beware!

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ initial_content:
 	curl -u admin:$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) -H "Content-Type: application/json" -d "@demo-data/browse-collections.json" https://${DOMAIN}/node?_format=json
 .PHONY: kitchen_sink
 .SILENT: kitchen_sink
-## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, CODE SERVER. NOT FOR PRODUCTION!!!
+## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, except CODE SERVER. NOT FOR PRODUCTION!!!
 kitchen_sink:
 	echo 'Exposing everything including the kitchen sink...'
 ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
@@ -415,11 +415,11 @@ ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
 	sed --in-place='' 's/EXPOSE_BLAZEGRAPH=false/EXPOSE_BLAZEGRAPH=true/g' .env
 	sed --in-place='' 's/EXPOSE_ACTIVEMQ=false/EXPOSE_ACTIVEMQ=true/g' .env
 	sed --in-place='' 's/EXPOSE_SOLR=false/EXPOSE_SOLR=true/g' .env
-	sed --in-place='' 's/EXPOSE_CODE_SERVER=false/EXPOSE_CODE_SERVER=true/g' .env
-	sed --in-place='' 's/INCLUDE_CODE_SERVER_SERVICE=false/INCLUDE_CODE_SERVER_SERVICE=true/g' .env
-	$(MAKE) docker-compose.yml
 	$(MAKE) build
+	$(MAKE) pull ENVIRONMENT=$(ENVIRONMENT)
 	$(MAKE) up
+	$(MAKE) hydrate ENVIRONMENT=$(ENVIRONMENT)
+	$(MAKE) reindex-solr ENVIRONMENT=$(ENVIRONMENT)
 	echo "Complete"
 	echo "You can now access the following endpoints:"
 	echo "Drupal:                               https://$(DOMAIN)"
@@ -430,7 +430,6 @@ ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
 	echo "Solr:                                 http://$(DOMAIN):8983/solr/#/"
 	echo "Cantaloupe:                           https://$(DOMAIN)/cantaloupe"
 	echo "Matomo:                               https://$(DOMAIN)/matomo/"
-	echo "Code Server (Code Editor in Browser): https://$(DOMAIN):8443/"
 else
 	echo ""
 	echo "Problem: Run this after you've run one of the make commands to build isle-dc (up, demo, local, etc.). Exiting..."

--- a/Makefile
+++ b/Makefile
@@ -321,28 +321,28 @@ download-default-certs:
 .SILENT: demo
 ## Make a demo site.
 demo: generate-secrets
-	$(MAKE) download-default-certs ENVIROMENT=demo
-	$(MAKE) -B docker-compose.yml ENVIROMENT=demo
-	$(MAKE) pull ENVIROMENT=demo
-	mkdir -p "$(CURDIR)/codebase"
+	$(MAKE) download-default-certs ENVIRONMENT=demo
+	$(MAKE) -B docker-compose.yml ENVIRONMENT=demo
+	$(MAKE) pull ENVIRONMENT=demo
+	mkdir -p $(CURDIR)/codebase
 	docker-compose up -d
-	$(MAKE) update-settings-php ENVIROMENT=demo
-	$(MAKE) drupal-public-files-import SRC="$(CURDIR)/demo-data/public-files.tgz" ENVIROMENT=demo
-	$(MAKE) drupal-database ENVIROMENT=demo
-	$(MAKE) drupal-database-import SRC="$(CURDIR)/demo-data/drupal.sql" ENVIROMENT=demo
-	$(MAKE) hydrate ENVIROMENT=demo
+	$(MAKE) update-settings-php ENVIRONMENT=demo
+	$(MAKE) drupal-public-files-import SRC=$(CURDIR)/demo-data/public-files.tgz ENVIRONMENT=demo
+	$(MAKE) drupal-database ENVIRONMENT=demo
+	$(MAKE) drupal-database-import SRC=$(CURDIR)/demo-data/drupal.sql ENVIRONMENT=demo
+	$(MAKE) hydrate ENVIRONMENT=demo
 	docker-compose exec -T drupal with-contenv bash -lc 'drush --root /var/www/drupal/web -l $${DRUPAL_DEFAULT_SITE_URL} upwd admin $${DRUPAL_DEFAULT_ACCOUNT_PASSWORD}'
-	$(MAKE) fcrepo-import SRC="$(CURDIR)/demo-data/fcrepo-export.tgz" ENVIROMENT=demo
-	$(MAKE) reindex-fcrepo-metadata ENVIROMENT=demo
-	$(MAKE) reindex-solr ENVIROMENT=demo
-	$(MAKE) reindex-triplestore ENVIROMENT=demo
+	$(MAKE) fcrepo-import SRC=$(CURDIR)/demo-data/fcrepo-export.tgz ENVIRONMENT=demo
+	$(MAKE) reindex-fcrepo-metadata ENVIRONMENT=demo
+	$(MAKE) reindex-solr ENVIRONMENT=demo
+	$(MAKE) reindex-triplestore ENVIRONMENT=demo
 
 .PHONY: local
 .SILENT: local
 ## Make a local site with codebase directory bind mounted.
 local: QUOTED_CURDIR = "$(CURDIR)"
 local: generate-secrets
-	$(MAKE) download-default-certs ENVIROMENT=local
+	$(MAKE) download-default-certs ENVIRONMENT=local
 	$(MAKE) -B docker-compose.yml ENVIRONMENT=local
 	$(MAKE) pull ENVIRONMENT=local
 	mkdir -p "$(CURDIR)/codebase"
@@ -387,15 +387,10 @@ local-install-profile: generate-secrets
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIROMENT=local
 	docker-compose up -d --remove-orphans
 	docker-compose exec -T drupal with-contenv bash -lc 'composer install; chown -R nginx:nginx .'
-	$(MAKE) remove_standard_profile_references_from_config ENVIROMENT=local
+	$(MAKE) remove_standard_profile_references_from_config ENVIRONMENT=local
 	$(MAKE) install ENVIRONMENT=local
 	$(MAKE) hydrate ENVIRONMENT=local
-	# The - at the beginning is not a typo, it will allow this process to failing the make command.
-	-docker-compose exec -T drupal with-contenv bash -lc 'mkdir -p /var/www/drupal/config/sync && chmod -R 775 /var/www/drupal/config/sync'
-	docker-compose exec -T drupal with-contenv bash -lc 'chown -R `id -u`:101 /var/www/drupal'
-	docker-compose exec -T drupal with-contenv bash -lc 'drush migrate:rollback islandora_defaults_tags,islandora_tags'
-	$(MAKE) initial_content
-	$(MAKE) login
+	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
 
 .PHONY: initial_content
 initial_content:

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ local: generate-secrets
 ## Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, except CODE SERVER. NOT FOR PRODUCTION!!!
 kitchen_sink:
 	echo 'Exposing everything including the kitchen sink...'
-ifeq ($(shell test -e docker-compose.yml && echo -n yes),yes)
+ifeq ($(shell /usr/bin/env bash -c "test -e docker-compose.yml && echo -n yes"),yes)
 	$(MAKE) down
 	$(shell $(SED) 's/EXPOSE_CANTALOUPE=false/EXPOSE_CANTALOUPE=true/g' .env)
 	$(shell $(SED) 's/EXPOSE_MATOMO=false/EXPOSE_MATOMO=true/g' .env)

--- a/Makefile
+++ b/Makefile
@@ -336,6 +336,7 @@ demo: generate-secrets
 	$(MAKE) reindex-fcrepo-metadata ENVIRONMENT=demo
 	$(MAKE) reindex-solr ENVIRONMENT=demo
 	$(MAKE) reindex-triplestore ENVIRONMENT=demo
+	sed --in-place='' 's/ENVIRONMENT=local/ENVIRONMENT=demo/g' .env
 
 .PHONY: local
 .SILENT: local
@@ -391,6 +392,7 @@ local-install-profile: generate-secrets
 	$(MAKE) install ENVIRONMENT=local
 	$(MAKE) hydrate ENVIRONMENT=local
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
+	sed --in-place='' 's/ENVIRONMENT=demo/ENVIRONMENT=local/g' .env
 
 .PHONY: initial_content
 initial_content:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ funny url fool you, it's a dummy domain that resolves to `127.0.0.1`.
 If you do not have [secrets enabled](#secrets), you can log into Drupal as
 `admin` using the default password: `password`. Otherwise you can find the
 password in the file
-[./secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD](./secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD).
+[./secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD](/secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD).
 
 Enjoy your Islandora instance!  Check out the [Islandora documentation](https://islandora.github.io/documentation) to see all
 the things you can do.  If you want to poke around, here's all the services that are available to visit:

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ the things you can do.  If you want to poke around, here's all the services that
 | Service     | Url                                                                                            |
 | :---------- | :--------------------------------------------------------------------------------------------- |
 | Drupal      | [https://islandora.traefik.me](https://islandora.traefik.me)                                   |
-| Traefik     | [https://islandora.traefik.me:8080](https://islandora.traefik.me:8080)                         |
-| Fedora      | [https://islandora.traefik.me:8081/fcrepo/rest](https://islandora.traefik.me:8081/fcrepo/rest) |
-| Blazegraph  | [https://islandora.traefik.me:8082/bigdata](https://islandora.traefik.me:8082/bigdata)         |
-| Activemq    | [https://islandora.traefik.me:8161](https://islandora.traefik.me:8161)                         |
-| Solr        | [https://islandora.traefik.me:8983](https://islandora.traefik.me:8983)                         |
+| Traefik     | [http://islandora.traefik.me:8080](http://islandora.traefik.me:8080)                         |
+| Fedora      | [http://islandora.traefik.me:8081/fcrepo/rest](http://islandora.traefik.me:8081/fcrepo/rest) |
+| Blazegraph  | [http://islandora.traefik.me:8082/bigdata](http://islandora.traefik.me:8082/bigdata)         |
+| Activemq    | [http://islandora.traefik.me:8161](http://islandora.traefik.me:8161)                         |
+| Solr        | [http://islandora.traefik.me:8983](http://islandora.traefik.me:8983)                         |
 | Cantaloupe  | [https://islandora.traefik.me/cantaloupe](https://islandora.traefik.me/cantaloupe)             |
 | Matomo      | [https://islandora.traefik.me/matomo/](https://islandora.traefik.me/matomo/)                   |
 | Code Server | [https://islandora.traefik.me:8443/](https://islandora.traefik.me:8443/)                       |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ the things you can do.  If you want to poke around, here's all the services that
 | Matomo      | [https://islandora.traefik.me/matomo/](https://islandora.traefik.me/matomo/)                   |
 | Code Server | [https://islandora.traefik.me:8443/](https://islandora.traefik.me:8443/)                       |
 
+Expose all of the endpoints at once (for testing and demo purposes and NOT production) by running
+```bash
+make kitchen_sink
+```
+This will automatically stop the containers, modify the `.env` file, import the changes and restart the containers with the new configurations. See [#custom-environment](#custom-environment) for more information on building with custom environment settings.
+
 When you're done with your demo environment, shut it down by running
 
 ```bash
@@ -159,9 +165,15 @@ the guide above to create the codebase folder from the `islandora/demo` image.
 And then run it by changing `ENVIRONMENT` to be `custom` and regenerating the
 `docker-compose.yml` file and building the image.
 
+To pull in changes to the .env file run the following.
 ```bash
 make docker-compose.yml
 make build
+
+# then either
+docker-compose up -d
+# OR
+make up
 ```
 
 At this point you could run it using `docker-compose`:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ## Introduction
 
 [Docker Compose] project for creating and managing an Islandora 8 instance
-using [Docker] containers from [Docker Hub](https://hub.docker.com/u/islandora) 
+using [Docker] containers from [Docker Hub](https://hub.docker.com/u/islandora)
 that were created by [isle-buildkit](https://github.com/Islandora-Devops/isle-buildkit).
 
 In a nutshell, `isle-dc` generates a docker-compose.yml file for you based on configuration
@@ -40,7 +40,7 @@ as database import/export and reindexing.
 
 - Desktop / laptop / VM (*Docker must have sufficient resources to run GNU Make*)
 - Docker-CE 19.x+
-- Docker-compose version 1.25.x+ 
+- Docker-compose version 1.25.x+
 - Git 2.0+
 - GNU Make 4.0+
 - At least 8GB of RAM (ideally 16GB)
@@ -97,7 +97,7 @@ When you're done with your demo environment, shut it down by running
 docker-compose down
 ```
 
-This will keep your data around until the next time you start your instance.  If you want to completely destroy the repository and 
+This will keep your data around until the next time you start your instance.  If you want to completely destroy the repository and
 all ingested data, use
 
 ```
@@ -186,7 +186,7 @@ make down
 # Bring isle-dc back up from where it left off
 make up
 
-# If make hasn't been run this will run make demo 
+# If make hasn't been run this will run make demo
 
 ```
 


### PR DESCRIPTION
For testing, demo, documentation, etc. it's helpful to have everything on and easy to find. This adds a optional make command to expose the frontend URLs for Drupal, Traefik, Fedora, Blazegraph, Activemq, Solr, Cantaloupe, Matomo, and Code Server.

The output of running this will give the user the URLs specific to their configuration.
```bash
$ make kitchen_sink
...
You can now access the following endpoints:
Drupal:                               https://islandora.traefik.me
Traefik:                              http://islandora.traefik.me:8080/dashboard/#/
Fedora:                               http://islandora.traefik.me:8081/fcrepo/rest
Blazegraph:                           http://islandora.traefik.me:8082/bigdata/#splash
Activemq:                             http://islandora.traefik.me:8161
Solr:                                 http://islandora.traefik.me:8983/solr/#/
Cantaloupe:                           https://islandora.traefik.me/cantaloupe
Matomo:                               https://islandora.traefik.me/matomo/
Code Server (Code Editor in Browser): https://islandora.traefik.me:8443
```

The help message returns the following text
> Turn on/expose all endpoints for demo/testing; CANTALOUPE, MATOMO, DRUPAL, MYSQL, POSTGRES, TRAEFIK DASHBOARD, FEDORA, BLAZEGRAPH, ACTIVEMQ, SOLR, CODE SERVER. NOT FOR PRODUCTION!!!

## To test
The assumption the user has already started isle-dc and doesn't have any or all of the items already exposed. This looks within the `.env` file and replaces `false` to `true` for each one of the above mentioned services to expose the service.

Run the following
```bash
$ make kitchen_sink
```
Navigate to each one of the links it provided and verify all of the URLs work. Please note that `http` & `https` are NOT interchangeable. Please use the exact URL indicated in the terminal.

Also review the added documentation for clarity on how to use this make command.

## Additional house cleaning
1. The services URLs list had all services set to https and this is incorrect.
1. Link to /secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD was incorrect
1. There was some white space at the end of a few lines