### PR TITLE
Fix the TAG/DRUPAL_INSTALL_PROFILE 

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -65,7 +65,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=aed5adc95784c1dd24589a0f77c3bbb063c92113
+TAG=1.0.0-alpha-15
 
 ###############################################################################
 # Exposed Containers & Ports
@@ -129,7 +129,7 @@ PHP_MAX_EXECUTION_TIME=30
 
 # If you're just demoing or are starting from scratch, use this.
 INSTALL_EXISTING_CONFIG=false
-DRUPAL_INSTALL_PROFILE=islandora_install_profile_demo
+DRUPAL_INSTALL_PROFILE=standard
 
 # If you're installing from an existing codebase, uncomment this
 #INSTALL_EXISTING_CONFIG=true


### PR DESCRIPTION
Currently, these are breaking the build. Likely because an install profile PR hasn't been merged yet. This is to set it back to a workable option.

## To test
* Prior to switching to this PR try to build from a clean state. In other words, run `make clean`.
* Run `make up` or `make local`

If it properly builds without issue this would be a successful test.