### PR TITLE
Load env changes with single make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,9 +454,8 @@ confirm:
 	@echo -n "Are you sure you want to continue and drop your data? [y/N] " && read ans && [ $${ans:-N} = y ]
 
 RESET=$(shell tput sgr0)
-RED=$(shell tput setaf 1)
-GREEN=$(shell tput setaf 2)
-YELLOW=$(shell tput setaf 3)
+RED=$(shell tput setaf 9)
+BLUE=$(shell tput setaf 6)
 TARGET_MAX_CHAR_NUM=20
 
 .PHONY: help
@@ -464,7 +463,7 @@ TARGET_MAX_CHAR_NUM=20
 help:
 	@echo ''
 	@echo 'Usage:'
-	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo '  ${RED}make${RESET} ${BLUE}<target>${RESET}'
 	@echo ''
 	@echo 'Targets:'
 	# @grep '^.PHONY: .* #' Makefile | sed 's/\.PHONY: \(.*\) # \(.*\)/\1 \2/'
@@ -473,7 +472,7 @@ help:
 		if (helpMessage) { \
 			helpCommand = $$1; sub(/:$$/, "", helpCommand); \
 			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
-			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+			printf "  ${RED}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${BLUE}%s${RESET}\n", helpCommand, helpMessage; \
 		} \
 	} \
 	{lastLine = $$0}' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -453,6 +453,12 @@ env:
 confirm:
 	@echo -n "Are you sure you want to continue and drop your data? [y/N] " && read ans && [ $${ans:-N} = y ]
 
+RESET=$(shell tput sgr0)
+RED=$(shell tput setaf 1)
+GREEN=$(shell tput setaf 2)
+YELLOW=$(shell tput setaf 3)
+TARGET_MAX_CHAR_NUM=20
+
 .PHONY: help
 .SILENT: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ docker-compose.yml: $(SERVICES:%=docker-compose.%.yml) .env
 	docker-compose $(SERVICES:%=-f docker-compose.%.yml) config > docker-compose.yml
 
 .PHONY: pull
-## _ Fetches the latest images from the registry.
+## Fetches the latest images from the registry.
 pull: docker-compose.yml
 ifeq ($(REPOSITORY), local)
 	# Only need to pull external services if using local images.
@@ -103,7 +103,7 @@ else
 endif
 
 .PHONY: build
-## _ Create Dockerfile from example if it does not exist.
+## Create Dockerfile from example if it does not exist.
 build:
 	if [ ! -f $(PROJECT_DRUPAL_DOCKERFILE) ]; then \
 		cp "$(CURDIR)/sample.Dockerfile" $(PROJECT_DRUPAL_DOCKERFILE); \
@@ -174,7 +174,7 @@ namespaces:
 
 .PHONY: hydrate
 .SILENT: hydrate
-## _ Reconstitute the site from environment variables.
+## Reconstitute the site from environment variables.
 hydrate: update-settings-php update-config-from-environment solr-cores namespaces run-islandora-migrations
 	docker-compose exec -T drupal drush cr -y
 
@@ -201,14 +201,14 @@ remove_standard_profile_references_from_config:
 
 .PHONY: config-export
 .SILENT: config-export
-## _ Exports the sites configuration.
+## Exports the sites configuration.
 config-export:
 	docker-compose exec -T drupal drush -l $(SITE) config:export -y
 
 
 .PHONY: config-import
 .SILENT: config-import
-## _ Import the sites configuration. N.B You may need to run this multiple times in succession due to errors in the configurations dependencies.
+## Import the sites configuration. N.B You may need to run this multiple times in succession due to errors in the configurations dependencies.
 config-import: set-site-uuid delete-shortcut-entities
 	docker-compose exec -T drupal drush -l $(SITE) config:import -y
 
@@ -319,7 +319,7 @@ download-default-certs:
 
 .PHONY: demo
 .SILENT: demo
-## _ Make a demo site.
+## Make a demo site.
 demo: generate-secrets
 	$(MAKE) download-default-certs ENVIROMENT=demo
 	$(MAKE) -B docker-compose.yml ENVIROMENT=demo
@@ -339,7 +339,7 @@ demo: generate-secrets
 
 .PHONY: local
 .SILENT: local
-## _ Make a local site with codebase directory bind mounted.
+## Make a local site with codebase directory bind mounted.
 local: QUOTED_CURDIR = "$(CURDIR)"
 local: generate-secrets
 	$(MAKE) download-default-certs ENVIROMENT=local
@@ -405,7 +405,7 @@ initial_content:
 # Destroys everything beware!
 .PHONY: clean
 .SILENT: clean
-## _ Destroys everything beware!
+## Destroys everything beware!
 clean:
 	echo "**DANGER** About to rm your SERVER data subdirs, your docker volumes and your codebase/web"
 	$(MAKE) confirm
@@ -415,7 +415,7 @@ clean:
 
 .PHONY: up
 .SILENT: up
-## _ Brings up the containers or builds demo if no containers were found.
+## Brings up the containers or builds demo if no containers were found.
 up:
 	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) demo
 	@echo "\n Sleeping for 10 seconds to wait for Drupal to finish building.\n"
@@ -424,7 +424,7 @@ up:
 
 .PHONY: down
 .SILENT: down
-## _ Brings down the containers. Same as docker-compose down --remove-orphans
+## Brings down the containers. Same as docker-compose down --remove-orphans
 down:
 	-docker-compose down --remove-orphans
 
@@ -437,7 +437,7 @@ login:
 
 .PHONY: env
 .SILENT: env
-## _ Pull in changes to the .env file.
+## Pull in changes to the .env file.
 env:
 	if [ -f .env ]; then \
 		$(MAKE) down ; \
@@ -482,7 +482,7 @@ CMD := $(shell [ $(IS_DRUPAL_PSSWD_FILE_READABLE) -eq 1 ] && echo 'tee' || echo 
 
 .PHONY: set_admin_password
 .SILENT: set_admin_password
-## _ Sets the admin password and accomodates for permissions restrictions to the secrets directory. Only runs sudo when needed.
+## Sets the admin password and accomodates for permissions restrictions to the secrets directory. Only runs sudo when needed.
 set_admin_password:
 	@$(eval PASSWORD ?= $(shell bash -c 'read -s -p "New Password: " pwd; echo $$pwd'))
 	@echo "\n\nSetting admin password now"
@@ -494,7 +494,7 @@ LATEST_VERSION := $(shell curl -s https://api.github.com/repos/desandro/masonry/
 
 .PHONY: fix-masonry
 .SILENT: fix-masonry
-## _ Fix missing masonry library.
+## Fix missing masonry library.
 fix-masonry:
 	@echo "Latest version of masonry library is ${LATEST_VERSION}"
 	docker-compose exec drupal bash -lc "[ -d '/var/www/drupal/web/libraries' ] && exit ; mkdir -p /var/www/drupal/web/libraries ; chmod 755 /var/www/drupal/web/libraries ; chown 1000:nginx /var/www/drupal/web/libraries"

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ docker-compose.yml: $(SERVICES:%=docker-compose.%.yml) .env
 	docker-compose $(SERVICES:%=-f docker-compose.%.yml) config > docker-compose.yml
 
 .PHONY: pull
-## _ ← Fetches the latest images from the registry.
+## _ Fetches the latest images from the registry.
 pull: docker-compose.yml
 ifeq ($(REPOSITORY), local)
 	# Only need to pull external services if using local images.
@@ -103,7 +103,7 @@ else
 endif
 
 .PHONY: build
-## _ ← Create Dockerfile from example if it does not exist.
+## _ Create Dockerfile from example if it does not exist.
 build:
 	if [ ! -f $(PROJECT_DRUPAL_DOCKERFILE) ]; then \
 		cp "$(CURDIR)/sample.Dockerfile" $(PROJECT_DRUPAL_DOCKERFILE); \


### PR DESCRIPTION
Keeping with the idea of helping the user from needing to know/use docker/docker-compose commands and simplifying the process.

This adds `make env` to fetch the changes made to the .env file post-build. 

## To test
Run `make clean` to start with a clean environment then run `make env`

It should fail with a message "No .env file found." and exit with doing nothing to the system.

- Now run `make local` to build the system. This will automatically create a .env file. 
- Navigate to http://islandora.traefik.me:8983/solr/#/ and this should give you a 404. Watch out! Your browser might try to redirect you to the HTTPS equivalent. This will not work. Switch it back to HTTP manually.
- Modify the .env file to expose solr
- Run `make help` and the output should include " env _ Pull in changes to the .env file.`
- Run `make env` and navigate to http://islandora.traefik.me:8983/solr/#/

Also added some text formatting to the help definitions.