### PR TITLE
Acme updates -- Allow for External Account Binding

### DIFF
--- a/build/docker-compose/docker-compose.acme.yml
+++ b/build/docker-compose/docker-compose.acme.yml
@@ -17,7 +17,7 @@ services:
       - --entryPoints.activemq.address=:8161
       - --entryPoints.solr.address=:8983
       - --entryPoints.code-server.address=:8443
-      - --log.level=${TRAEFIK_LOG_LEVEL-ERROR}
+      - --log.level=${TRAEFIK_LOG_LEVEL:-ERROR}
       - --providers.docker
       - --providers.docker.network=gateway
       - --providers.docker.exposedByDefault=false

--- a/build/docker-compose/docker-compose.acme.yml
+++ b/build/docker-compose/docker-compose.acme.yml
@@ -26,8 +26,12 @@ services:
       - --certificatesresolvers.myresolver.acme.httpchallenge=true
       - --certificatesresolvers.myresolver.acme.httpchallenge.entrypoint=http
       - --certificatesresolvers.myresolver.acme.email=${ACME_EMAIL-your-email@example.com}
+      - --certificatesresolvers.myresolver.acme.keyType=${ACME_KEY_TYPE-RSA4096}
       - --certificatesresolvers.myresolver.acme.storage=/acme/acme.json
       - --certificatesResolvers.myresolver.acme.caServer=${ACME_SERVER-https://acme-v02.api.letsencrypt.org/directory}
+      - --certificatesresolvers.myresolver.acme.certificatesduration=${ACME_CERT_DURATION-2160}
+      - --certificatesresolvers.myresolver.acme.eab.kid=${ACME_EAB_KID-}
+      - --certificatesresolvers.myresolver.acme.eab.hmacencoded=${ACME_EAB_HMAC-}
     volumes:
       - ../../acme:/acme:rw
   cantaloupe:

--- a/sample.env
+++ b/sample.env
@@ -35,6 +35,7 @@ PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.
 INCLUDE_TRAEFIK_SERVICE=true
+TRAEFIK_LOG_LEVEL=ERROR
 
 # Should we use ACME to generate a SSL Certificate
 USE_ACME=false

--- a/sample.env
+++ b/sample.env
@@ -40,6 +40,15 @@ INCLUDE_TRAEFIK_SERVICE=true
 USE_ACME=false
 # Specify email to tie SSL Certificate to with ACME provider
 ACME_EMAIL=your-email@example.com
+# KeyType used for generating certificate private key. Allow value 'EC256', 'EC384', 'RSA2048', 'RSA4096', 'RSA8192'.
+ACME_KEY_TYPE=RSA4096
+
+# ACME Defaults for Let's Encrypt Service
+# ACME_SERVER=https://acme-v02.api.letsencrypt.org/directory
+# Default duration for the certificate is 90 days or 2,160 hours for Let's Encrypt
+# ACME_CERT_DURATION=2160
+# ACME_EAB_KID=
+# ACME_EAB_HMAC=
 
 # Includes `watchtower` as a service.
 INCLUDE_WATCHTOWER_SERVICE=false


### PR DESCRIPTION
Adds support for External Account Binding with ACME

Allows for the support of External Account Binding to request SSL Certificates through a provider that supports EAB and ACME.

Some example providers include InCommon and ZeroSSL

I also exposed the `TRAEFIK_LOG_LEVEL` in the sample.env instead of hiding it.


Possible test plan:

## Ensure existing setups still work:

1. Merge code
2. remove acme directory if it already exists
3. run `make -B docker-compose.yml`
4. run `make up`
5. Visit website, and ensure have an SSL cert from Let's Encrypt that is valid starting from date tested (should expire in 90 days)

## Ensure new SSL Certificate from an ACME provider with an External Account Binding (EAB)works
1. Merge code
2. remove acme directory if it already exists
3. Add in valid values for `ACME_SERVER`, `ACME_EAB_KID`, `ACME_EAB_HMAC` 
4. run `make -B docker-compose.yml`
5. run `make up`
6. Visit website, and ensure have an SSL cert from your SSL provider that is valid starting from date tested


For more info about EAB from Traefik please visit https://doc.traefik.io/traefik/https/acme/#external-account-binding

For some info about EAB and ACME from ZeroSSL please see https://zerossl.com/documentation/acme/ ... I have an Incommon account, so I did not look into ZeroSSL, but assuming it is a similar setup??



# Related Tickets
https://github.com/Islandora-Devops/isle-dc/pull/253 (Merged)
https://github.com/Islandora-Devops/isle-dc/pull/252
https://github.com/Islandora/documentation/pull/2096