### PR TITLE
Add custom Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ ENV_FILE=$(shell \
 	fi; \
 	echo .env)
 
+# If custom.makefile exists include it.
+if [ -f custom.Makefile ]; then
+	include custom.Makefile
+fi
+
 # Checks to see if the path includes a space character. Intended to be a temporary fix.
 ifneq (1,$(words $(CURDIR)))
 $(error Containing path cannot contain space characters: '$(CURDIR)')

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,7 @@ ENV_FILE=$(shell \
 	echo .env)
 
 # If custom.makefile exists include it.
-if [ -f custom.Makefile ]; then
-	include custom.Makefile
-fi
+-include custom.Makefile
 
 # Checks to see if the path includes a space character. Intended to be a temporary fix.
 ifneq (1,$(words $(CURDIR)))


### PR DESCRIPTION
This adds a check in the Makefile that looks for the existence of a custom.Makefile. If the file exist it will include it. Full instructions were added to the README. 

## To test
Using the instructions in the README you should be able to create a custom.Makefile and it should automatically recognize it when you run any make commands.