### PR TITLE
Fix make env 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,12 @@ env:
 		$(MAKE) -B docker-compose.yml ; \
 		$(MAKE) pull ; \
 		$(MAKE) up ; \
+		echo -e '\n\n${BLUE}Fixing the error message: ${RESET} ${RED}In Filesystem.php line 203${RESET}\n\n' ; \
+		docker-compose exec -T drupal with-contenv bash -lc "cp /var/www/drupal/web/sites/default/settings.php /var/www/drupal/web/sites/default/settings.php.bak" ; \
+		docker-compose exec -T drupal with-contenv bash -lc "cp /var/www/drupal/web/sites/default/default.settings.php /var/www/drupal/web/sites/default/settings.php" ; \
+		docker-compose exec -T drupal with-contenv bash -lc "chown nginx:nginx /var/www/drupal/web/sites/default/settings.php" ; \
+		docker-compose exec -T drupal with-contenv bash -lc "chmod 644 /var/www/drupal/web/sites/default/settings.php" ; \
+		$(MAKE) update-settings-php ; \
 	fi
 	if [ ! -f .env ]; then \
 		echo "No .env file found." ; \


### PR DESCRIPTION
For some reason, this command is suddenly causing major permissions errors with the settings.php

Drupal resets to the install page instead of the home page.

## To test
Run `make env` and when it finishes you should be able to load the site. 