### PR TITLE
Update to use latest containers, fixes issue with houdini and ghostscript amongst others

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -65,7 +65,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=1.0.0-alpha-16
+TAG=1.0.7
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
While testing https://github.com/Islandora-Devops/islandora_install_profile_demo/pull/11 it became apparent that some of the minor fixes to the ISLE containers are required for the full stack to work, and there's no reason to stay on the ALPHA containers. This change would update all new projects to start with 1.0.7, not 1.0.0-alpha-16