### PR TITLE
let demo_content target in makefile run multiple times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -377,7 +377,7 @@ ifeq ($(shell uname -s),Darwin)
 	sed -i '' 's/^nopassword.*/password\: $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) /g' islandora_workbench/demoBDcreate*
 	sed -i '' 's/http:/https:/g' islandora_workbench/demoBDcreate*
 endif
-	sed -i '' 's/author_email\="mjordan@sfu"\,/author_email="mjordan@sfu", packages=["i7Import", "i8demo_BD", "input_data"],/g' islandora_workbench/setup.py
+	sed -i '' '/packages\=/! s/author_email\="mjordan@sfu"\,/author_email="mjordan@sfu", packages=["i7Import", "i8demo_BD", "input_data"],/' islandora_workbench/setup.py
 	cd islandora_workbench && docker build -t workbench-docker .
 	cd islandora_workbench && docker run -it --rm --network="host" -v $(shell pwd)/islandora_workbench:/workbench --name my-running-workbench workbench-docker bash -lc "(cd /workbench && python setup.py install 2>&1 && ./workbench --config demoBDcreate_all_localhost.yml)"
 	$(MAKE) reindex-solr


### PR DESCRIPTION
To test:
- run make demo_content two or more times
- second time throws a python error ( see below)
- apply patch
- run make demo_content multiple times
- no error

----

I ran into some trouble building the demo site and had to run `make demo` multiple times, but on iterations after the first I kept seeing this error related to running setup.py in Islandora workbench:

```py
File "/workbench/setup.py", line 7
    author_email="mjordan@sfu", packages=["i7Import", "i8demo_BD", "input_data"], packages=["i7Import", "i8demo_BD", "input_data"],
                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: keyword argument repeated: packages
```

I tracked the problem back to the final `sed` command in the `demo_content` target; it replaces "author_email="mjordan@sfu", with "author_email="mjordan@sfu", packages=[... but it's happy to do that multiple times, leading to the error above. Most other things in the repeat run seemed to work despite some warnings. I just modified the `sed` so it'll only run the substitution on the line if the line doesn't already have "packages" listed. I also removed sed's "g" flag since I don't think a global substitution makes sense here.

I realize this is an edge case since people shouldn't be running `make demo` multiple times without cleaning things out in between but it came up for me so I figured I'd submit a PR.