### PR TITLE
Update `make clean` warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,7 +388,7 @@ demo_content:
 .SILENT: clean
 ## Destroys everything beware!
 clean:
-	echo "**DANGER** About to rm your SERVER data subdirs, your docker volumes and your codebase/web"
+	echo "**DANGER** About to rm your SERVER data subdirs, your docker volumes, codebase, islandora_workbench, certs, secrets, and all untracked/ignored files (including .env)."
 	$(MAKE) confirm
 	-docker-compose down -v
 	sudo rm -fr codebase islandora_workbench certs secrets/live/*


### PR DESCRIPTION
I realized the warning that `make clean` will delete your `SERVER data subdirs, your docker volumes and your codebase/web"` is misleading because `make clean` deletes the entire codebase directory, as well as a whole lot more. This is my attempt at an improvement.