### PR TITLE
Allow composer operations after starter project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -562,6 +562,6 @@ starter-finalize:
 	docker-compose exec -T drupal with-contenv bash -lc "drush -l $(SITE) user:role:add fedoraadmin admin"
 	MIGRATE_IMPORT_USER_OPTION=--userid=1 $(MAKE) hydrate
 	docker-compose exec -T drupal with-contenv bash -lc 'drush -l $(SITE) migrate:import --userid=1 islandora_fits_tags'
-	#docker-compose exec -T drupal with-contenv bash -lc 'chown -R `id -u`:nginx /var/www/drupal'
-	#docker-compose exec -T drupal with-contenv bash -lc 'drush migrate:rollback islandora_defaults_tags,islandora_tags'
+	docker-compose exec -T drupal with-contenv bash -lc 'chown -R `id -u`:nginx /var/www/drupal'
+	docker-compose exec drupal bash -c "chmod u+w web/sites/default/settings.php"
 	$(MAKE) login


### PR DESCRIPTION
As per https://github.com/Islandora-Devops/isle-dc/issues/306, the current `starter` and `starter_dev` leave the `codebase` with permissions that do not allow further composer operations without surgery. I tweaked the end of the `finalize-starter` function to address this. 

To replicate:
* Checkout this branch
* `make clean` then `make starter_dev` and then `docker-compose exec drupal bash -c "composer update"`

Results for me (success!):

```
Noahs-M2-MBP-4:isle-dc-2 noah$ docker-compose exec drupal bash
bash-5.1# composer update
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 1 install, 25 updates, 0 removals
  - Upgrading consolidation/annotated-command (4.5.6 => 4.6.1)
  - Upgrading consolidation/output-formatters (4.2.2 => 4.2.3)
  - Upgrading consolidation/site-alias (3.1.5 => 3.1.7)
  - Upgrading consolidation/site-process (4.2.0 => 4.2.1)
  - Upgrading doctrine/event-manager (1.1.2 => 1.2.0)
  - Locking drupal/ctools (4.0.1)
  - Upgrading drupal/field_group (3.3.0 => 3.4.0)
  - Upgrading drupal/search_api (1.27.0 => 1.28.0)
  - Upgrading islandora/islandora (2.4.3 => 2.5.0)
  - Upgrading islandora/openseadragon (2.0.2 => 2.0.3)
  - Upgrading nesbot/carbon (2.62.1 => 2.63.0)
  - Upgrading nikic/php-parser (v4.15.1 => v4.15.2)
  - Upgrading symfony/console (v4.4.45 => v4.4.48)
  - Upgrading symfony/http-foundation (v4.4.46 => v4.4.48)
  - Upgrading symfony/http-kernel (v4.4.46 => v4.4.48)
  - Upgrading symfony/polyfill-intl-grapheme (v1.26.0 => v1.27.0)
  - Upgrading symfony/polyfill-php72 (v1.26.0 => v1.27.0)
  - Upgrading symfony/polyfill-php73 (v1.26.0 => v1.27.0)
  - Upgrading symfony/property-access (v5.4.11 => v5.4.15)
  - Upgrading symfony/property-info (v5.4.11 => v5.4.15)
  - Upgrading symfony/security (v4.4.46 => v4.4.48)
  - Upgrading symfony/serializer (v4.4.45 => v4.4.47)
  - Upgrading symfony/string (v5.4.13 => v5.4.15)
  - Upgrading symfony/translation (v4.4.45 => v4.4.47)
  - Upgrading symfony/validator (v4.4.46 => v4.4.48)
  - Upgrading symfony/var-dumper (v5.4.13 => v5.4.14)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 25 updates, 0 removals
  - Downloading symfony/polyfill-php73 (v1.27.0)
  - Downloading symfony/console (v4.4.48)
  - Downloading consolidation/output-formatters (4.2.3)
  - Downloading doctrine/event-manager (1.2.0)
  - Downloading symfony/polyfill-php72 (v1.27.0)
  - Downloading symfony/validator (v4.4.48)
  - Downloading symfony/translation (v4.4.47)
  - Downloading symfony/serializer (v4.4.47)
  - Downloading symfony/http-foundation (v4.4.48)
  - Downloading symfony/var-dumper (v5.4.14)
  - Downloading symfony/http-kernel (v4.4.48)
  - Downloading drupal/field_group (3.4.0)
  - Downloading drupal/search_api (1.28.0)
  - Downloading consolidation/annotated-command (4.6.1)
  - Downloading nikic/php-parser (v4.15.2)
  - Downloading consolidation/site-alias (3.1.7)
  - Downloading consolidation/site-process (4.2.1)
  - Downloading nesbot/carbon (2.63.0)
  - Downloading symfony/polyfill-intl-grapheme (v1.27.0)
  - Downloading symfony/string (v5.4.15)
  - Downloading symfony/property-info (v5.4.15)
  - Downloading symfony/property-access (v5.4.15)
  - Downloading symfony/security (v4.4.48)
  - Downloading drupal/ctools (4.0.1)
  - Downloading islandora/islandora (2.5.0)
  - Downloading islandora/openseadragon (2.0.3)
  - Upgrading symfony/polyfill-php73 (v1.26.0 => v1.27.0): Extracting archive
  - Upgrading symfony/console (v4.4.45 => v4.4.48): Extracting archive
  - Upgrading consolidation/output-formatters (4.2.2 => 4.2.3): Extracting archive
  - Upgrading doctrine/event-manager (1.1.2 => 1.2.0): Extracting archive
  - Upgrading symfony/polyfill-php72 (v1.26.0 => v1.27.0): Extracting archive
  - Upgrading symfony/validator (v4.4.46 => v4.4.48): Extracting archive
  - Upgrading symfony/translation (v4.4.45 => v4.4.47): Extracting archive
  - Upgrading symfony/serializer (v4.4.45 => v4.4.47): Extracting archive
  - Upgrading symfony/http-foundation (v4.4.46 => v4.4.48): Extracting archive
  - Upgrading symfony/var-dumper (v5.4.13 => v5.4.14): Extracting archive
  - Upgrading symfony/http-kernel (v4.4.46 => v4.4.48): Extracting archive
  - Upgrading drupal/field_group (3.3.0 => 3.4.0): Extracting archive
  - Upgrading drupal/search_api (1.27.0 => 1.28.0): Extracting archive
  - Upgrading consolidation/annotated-command (4.5.6 => 4.6.1): Extracting archive
  - Upgrading nikic/php-parser (v4.15.1 => v4.15.2): Extracting archive
  - Upgrading consolidation/site-alias (3.1.5 => 3.1.7): Extracting archive
  - Upgrading consolidation/site-process (4.2.0 => 4.2.1): Extracting archive
  - Upgrading nesbot/carbon (2.62.1 => 2.63.0): Extracting archive
  - Upgrading symfony/polyfill-intl-grapheme (v1.26.0 => v1.27.0): Extracting archive
  - Upgrading symfony/string (v5.4.13 => v5.4.15): Extracting archive
  - Upgrading symfony/property-info (v5.4.11 => v5.4.15): Extracting archive
  - Upgrading symfony/property-access (v5.4.11 => v5.4.15): Extracting archive
  - Upgrading symfony/security (v4.4.46 => v4.4.48): Extracting archive
  - Installing drupal/ctools (4.0.1): Extracting archive
  - Upgrading islandora/islandora (2.4.3 => 2.5.0): Extracting archive
  - Upgrading islandora/openseadragon (2.0.2 => 2.0.3): Extracting archive
Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
Package silex/silex is abandoned, you should avoid using it. Use symfony/flex instead.
Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
Generating autoload files
68 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Scaffolding files for islandora/islandora-starter-site:
  - NOTICE Modifying existing file at [web-root]/sites/default/settings.php. Examine the contents and ensure that it came out correctly.
  - Append to [web-root]/sites/default/settings.php from assets/patches/default_settings.txt
```