### PR TITLE
Simplify mass chown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ set-files-owner: $(SRC)
 ifndef SRC
 	$(error SRC is not set)
 endif
-	sudo find "$(SRC)" -exec chown $(shell id -u):101 {} \;
+	sudo chown -R $(shell id -u):101 $(SRC)
 
 .PHONY: drupal-database
 ## Creates required databases for drupal site(s) using environment variables.


### PR DESCRIPTION
Optimization: use the recursive "chown" rather than "find" to apply perms.

Addresses #317 