### PR TITLE
Add new workbench changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,7 @@ local: generate-secrets
 .PHONY: demo_content
 #.SILENT: demo_content
 ## Helper function for demo sites: do a workbench import of sample objects
+demo_content: QUOTED_CURDIR = "$(CURDIR)"
 demo_content:
 	# fetch repo that has csv and binaries to data/samples
 	# if prod do this by default
@@ -379,7 +380,7 @@ demo_content:
 	cd islandora_workbench ; cd islandora_workbench_demo_content || git clone https://github.com/DonRichards/islandora_workbench_demo_content
 	$(SED_DASH_I) 's/^nopassword.*/password\: $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) /g' islandora_workbench/islandora_workbench_demo_content/example_content.yml
 	cd islandora_workbench && docker build -t workbench-docker .
-	cd islandora_workbench && docker run -it --rm --network="host" -v $(shell pwd):/workbench --name my-running-workbench workbench-docker bash -lc "./workbench --config /workbench/islandora_workbench_demo_content/example_content.yml"
+	cd islandora_workbench && docker run -it --rm --network="host" -v $(QUOTED_CURDIR)/islandora_workbench:/workbench --name my-running-workbench workbench-docker bash -lc "./workbench --config /workbench/islandora_workbench_demo_content/example_content.yml"
 	$(MAKE) reindex-solr
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -375,13 +375,12 @@ local: generate-secrets
 demo_content:
 	# fetch repo that has csv and binaries to data/samples
 	# if prod do this by default
-	# if [ -d "islandora_workbench" ]; then rm -rf islandora_workbench; fi
-	[ -d "islandora_workbench" ] || (git clone -b new_staging --single-branch https://github.com/DonRichards/islandora_workbench)
-	$(SED_DASH_I) 's/^nopassword.*/password\: $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) /g' islandora_workbench/demoBDcreate*
-	$(SED_DASH_I) 's/http:/https:/g' islandora_workbench/demoBDcreate*
-	$(SED_DASH_I) 's/author_email\="mjordan@sfu"\,$$/author_email="mjordan@sfu", packages=["i7Import", "i8demo_BD", "input_data"],/g' islandora_workbench/setup.py
+	# Once the blocker is merged this needs to be pointed at the main branch https://github.com/mjordan/islandora_workbench
+	[ -d "islandora_workbench" ] || (git clone -b update_docker --single-branch https://github.com/DonRichards/islandora_workbench)
+	cd islandora_workbench ; cd islandora_workbench_demo_content || git clone https://github.com/DonRichards/islandora_workbench_demo_content
+	$(SED_DASH_I) 's/^nopassword.*/password\: $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) /g' islandora_workbench/islandora_workbench_demo_content/example_content.yml
 	cd islandora_workbench && docker build -t workbench-docker .
-	cd islandora_workbench && docker run -it --rm --network="host" -v $(shell pwd)/islandora_workbench:/workbench --name my-running-workbench workbench-docker bash -lc "(cd /workbench && python setup.py install 2>&1 && ./workbench --config demoBDcreate_all_localhost.yml)"
+	cd islandora_workbench && docker run -it --rm --network="host" -v $(pwd):/workbench --name my-running-workbench workbench-docker bash -lc "./workbench --config /workbench/islandora_workbench_demo_content/example_content.yml"
 	$(MAKE) reindex-solr
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ demo_content:
 	cd islandora_workbench ; cd islandora_workbench_demo_content || git clone https://github.com/DonRichards/islandora_workbench_demo_content
 	$(SED_DASH_I) 's/^nopassword.*/password\: $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) /g' islandora_workbench/islandora_workbench_demo_content/example_content.yml
 	cd islandora_workbench && docker build -t workbench-docker .
-	cd islandora_workbench && docker run -it --rm --network="host" -v $(pwd):/workbench --name my-running-workbench workbench-docker bash -lc "./workbench --config /workbench/islandora_workbench_demo_content/example_content.yml"
+	cd islandora_workbench && docker run -it --rm --network="host" -v $(shell pwd):/workbench --name my-running-workbench workbench-docker bash -lc "./workbench --config /workbench/islandora_workbench_demo_content/example_content.yml"
 	$(MAKE) reindex-solr
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -375,8 +375,7 @@ local: generate-secrets
 demo_content:
 	# fetch repo that has csv and binaries to data/samples
 	# if prod do this by default
-	# Once the blocker is merged this needs to be pointed at the main branch https://github.com/mjordan/islandora_workbench
-	[ -d "islandora_workbench" ] || (git clone -b update_docker --single-branch https://github.com/DonRichards/islandora_workbench)
+	[ -d "islandora_workbench" ] || (git clone https://github.com/mjordan/islandora_workbench)
 	cd islandora_workbench ; cd islandora_workbench_demo_content || git clone https://github.com/DonRichards/islandora_workbench_demo_content
 	$(SED_DASH_I) 's/^nopassword.*/password\: $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD) /g' islandora_workbench/islandora_workbench_demo_content/example_content.yml
 	cd islandora_workbench && docker build -t workbench-docker .


### PR DESCRIPTION
Blocked by https://github.com/mjordan/islandora_workbench/pull/542 (merged)

## Purpose
This automates the demo_content function to utilize the latest of "workbench" and fetches the demo content in a new manner that workbench suggests.

The demo content contained large files, and this should be separate from the islandora_migrate tool itself. The media files and the configuration to ingest them are stored in a repo elsewhere. This brings the two repos together for demo content.

## To test
Run `make demo_content` from a clean machine. 

Additional documentation included within the demo content repo https://github.com/DonRichards/islandora_workbench_demo_content