### PR TITLE
Makefile additions for building and pushing custom images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,17 @@ starter_dev: generate-secrets
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 
+.PHONY: production
+production: generate-secrets
+	$(MAKE) download-default-certs
+	$(MAKE) -B docker-compose.yml
+	$(MAKE) pull
+	docker-compose up -d --remove-orphans
+	docker-compose exec -T drupal with-contenv bash -lc 'composer install; chown -R nginx:nginx .'
+	$(MAKE) remove_standard_profile_references_from_config drupal-database update-settings-php
+	docker-compose exec -T drupal with-contenv bash -lc "drush si -y --existing-config minimal --account-pass $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)"
+
+
 #############################################
 ## Helper Rules for managing your install  ##
 #############################################

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ build:
 	if [ ! -f $(PROJECT_DRUPAL_DOCKERFILE) ]; then \
 		cp "$(CURDIR)/sample.Dockerfile" $(PROJECT_DRUPAL_DOCKERFILE); \
 	fi
-	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t $(COMPOSE_PROJECT_NAME)_drupal --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) .
+	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t "$(CUSTOM_DRUPAL_NAMESPACE)/$(COMPOSE_PROJECT_NAME)_drupal" --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) .
 
 
 .PHONY: set-files-owner

--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,12 @@ build:
 	if [ ! -f $(PROJECT_DRUPAL_DOCKERFILE) ]; then \
 		cp "$(CURDIR)/sample.Dockerfile" $(PROJECT_DRUPAL_DOCKERFILE); \
 	fi
-	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t $(COMPOSE_PROJECT_NAME)_drupal --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) .
+	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t $(CUSTOM_DRUPAL_NAMESPACE)/$(COMPOSE_PROJECT_NAME)_drupal --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) .
 
+.PHONY: push-image
+## Push your custom drupal image to dockerhub or a container registry
+push-image:
+	docker push "$(CUSTOM_DRUPAL_NAMESPACE)/$(COMPOSE_PROJECT_NAME)_drupal"
 
 .PHONY: set-files-owner
 ## Updates codebase folder to be owned by the host user and nginx group.

--- a/Makefile
+++ b/Makefile
@@ -120,6 +120,10 @@ build:
 	fi
 	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t "$(CUSTOM_DRUPAL_NAMESPACE)/$(COMPOSE_PROJECT_NAME)_drupal" --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) .
 
+.PHONY: push-image
+## Push your custom drupal image to dockerhub or a container registry
+push-image:
+	docker push "$(CUSTOM_DRUPAL_NAMESPACE)/$(COMPOSE_PROJECT_NAME)_drupal"
 
 .PHONY: set-files-owner
 ## Updates codebase folder to be owned by the host user and nginx group.

--- a/README.md
+++ b/README.md
@@ -165,17 +165,18 @@ Then you can `git push` your site to Github and `git clone` it down whenever you
 
 This environment is used to run your custom `drupal` image which can be produced
 outside of this repository, or from another isle-dc instance, such as a local
-development environment as described above. You can specify a namespace and the
-image name in your `.env` file.
+development environment as described above. You can specify a namespace, the
+image name, and tag in your `.env` file.
 
 This assumes you have already created an image and have it stored in a container
 registry like Dockerhub or Gitlab. If you are setting this up for the first time
 you should first create a local environment as described above. Once you have
 your local environment created you can do the following:
 - In your .env set the name of the image to create using
-`COMPOSE_PROJECT_NAME` and the namespace using `CUSTOM_DRUPAL_NAMESPACE`
+`CUSTOM_IMAGE_NAME`, the namespace using `CUSTOM_IMAGE_NAMESPACE`, and the tag
+using `CUSTOM_IMAGE_TAG`
 - Run `make build` to create an image based on the codebase folder
-    - This will create an image named `namespace/projectname_drupal`
+    - This will create an image named `namespace/name:tag`
 - Run `make push-image` to push that image to your container registry
 
 For convenience a `sample.Dockerfile` is provided which `make build` will use to
@@ -187,9 +188,9 @@ Once you have done that you can create your production or staging site by:
 - Modify your .env
     - Set ENVIRONMENT=custom
     - Set DOMAIN=yourdomain.com
-    - Set the namespace and the name of the image using
-      `CUSTOM_DRUPAL_NAMESPACE` and `COMPOSE_PROJECT_NAME`
-        - They should be the same values as on your local machine
+    - Set the namespace, the name of the image, and the tag using
+      `CUSTOM_IMAGE_NAMESPACE`, `CUSTOM_IMAGE_NAME`, and `CUSTOM_IMAGE_TAG`
+        - They should be the same values you used on your local machine when creating the image
 - Create your production site using `make production`
 - Export the database from your local machine and import it to your production
 site

--- a/README.md
+++ b/README.md
@@ -164,37 +164,35 @@ Then you can `git push` your site to Github and `git clone` it down whenever you
 ## Custom Environment
 
 This environment is used to run your custom `drupal` image which can be produced
-outside of this repository. You can specify the image in your `.env` file using
-the settings `PROJECT_DRUPAL_DOCKERFILE` if you want to build it in the context
-of this repository. You can also set the memory limits for each containers here as well.
+outside of this repository, or from another isle-dc instance, such as a local
+development environment as described above. You can specify a namespace and the
+image name in your `.env` file.
 
-For convenience a `sample.Dockerfile` is provided from which you can generate a
-custom image from the [codebase](./codebase) folder. For example if you followed
-the guide above to create the codebase folder from the `islandora/demo` image.
+This assumes you have already created an image and have it stored in a container
+registry like Dockerhub or Gitlab. If you are setting this up for the first time
+you should first create a local environment as described above. Once you have
+your local environment created you can do the following:
+- In your .env set the name of the image to create using
+`COMPOSE_PROJECT_NAME` and the namespace using `CUSTOM_DRUPAL_NAMESPACE`
+- Run `make build` to create an image based on the codebase folder
+    - This will create an image named `namespace/projectname_drupal`
+- Run `make push-image` to push that image to your container registry
 
-And then run it by changing `ENVIRONMENT` to be `custom` and regenerating the
-`docker-compose.yml` file and building the image.
+For convenience a `sample.Dockerfile` is provided which `make build` will use to
+generate a custom image from the [codebase](./codebase) folder. For example if
+you followed the guide above to create the codebase folder from the
+`islandora/demo` image.
 
-```bash
-make docker-compose.yml
-make build
-```
-
-At this point you could run it using `docker-compose`:
-
-```bash
-make up
-# Or in some situations you could run this instead.
-docker-compose up -d
-```
-
-To specify an image created outside of this repository, you can add the
-following to `docker-compose.env.yml`:
-
-```yaml
-drupal:
-  image: YOUR_CUSTOM_IMAGE
-```
+Once you have done that you can create your production or staging site by:
+- Modify your .env
+    - Set ENVIRONMENT=custom
+    - Set DOMAIN=yourdomain.com
+    - Set the namespace and the name of the image using
+      `CUSTOM_DRUPAL_NAMESPACE` and `COMPOSE_PROJECT_NAME`
+        - They should be the same values as on your local machine
+- Create your production site using `make production`
+- Export the database from your local machine and import it to your production
+site
 
 ## Shutting down and bring back up
 To run a non-destructive shutdown and bring it back up without having to know the docker commands needed. This keeps all of the commands for basic operations within the make commands.

--- a/build/docker-compose/docker-compose.custom.yml
+++ b/build/docker-compose/docker-compose.custom.yml
@@ -11,7 +11,7 @@ volumes:
 services:
   # The service name is drupal that is the default host name used by micro-services etc.
   drupal:
-    image: ${CUSTOM_DRUPAL_NAMESPACE}/${COMPOSE_PROJECT_NAME}_drupal:latest
+    image: ${CUSTOM_IMAGE_NAMESPACE}/${CUSTOM_IMAGE_NAME}:${CUSTOM_IMAGE_TAG}
     environment:
       #
       # Set environment variables that allow use to install from an existing configuration.

--- a/build/docker-compose/docker-compose.custom.yml
+++ b/build/docker-compose/docker-compose.custom.yml
@@ -11,9 +11,7 @@ volumes:
 services:
   # The service name is drupal that is the default host name used by micro-services etc.
   drupal:
-    build:
-      context: ../../
-      dockerfile: ${PROJECT_DRUPAL_DOCKERFILE:-./Dockerfile}
+    image: ${CUSTOM_DRUPAL_NAMESPACE}/${COMPOSE_PROJECT_NAME}_drupal:latest
     environment:
       #
       # Set environment variables that allow use to install from an existing configuration.

--- a/sample.env
+++ b/sample.env
@@ -33,7 +33,8 @@ DOCKER_BUILDKIT=1
 PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 
 # Custom namespace for your created Drupal images (eg. your dockerhub username)
-# Used in the image name when running `make build`
+# preface this with a URL to use a container registry like Github or Gitlab
+# Used in the image name when running `make build` and `make push-image`
 CUSTOM_DRUPAL_NAMESPACE=mynamespace
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik

--- a/sample.env
+++ b/sample.env
@@ -35,7 +35,17 @@ PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 # Custom namespace for your created Drupal images (eg. your dockerhub username)
 # preface this with a URL to use a container registry like Github or Gitlab
 # Used in the image name when running `make build` and `make push-image`
-CUSTOM_DRUPAL_NAMESPACE=mynamespace
+CUSTOM_IMAGE_NAMESPACE=mynamespace
+
+# Image name of custom drupal image
+# This is used when pulling a custom image for environments set to custom and 
+# when building a custom image with make build
+CUSTOM_IMAGE_NAME=${COMPOSE_PROJECT_NAME}_drupal
+
+# Tag for custom image
+# This is used when pulling a custom image for environments set to custom and
+# when building a custom image with make build
+CUSTOM_IMAGE_TAG=latest
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.

--- a/sample.env
+++ b/sample.env
@@ -32,6 +32,10 @@ DOCKER_BUILDKIT=1
 # Dockerfile to use when building the custom project.
 PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 
+# Custom namespace for your created Drupal images (eg. your dockerhub username)
+# Used in the image name when running `make build`
+CUSTOM_DRUPAL_NAMESPACE=mynamespace
+
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.
 INCLUDE_TRAEFIK_SERVICE=true


### PR DESCRIPTION
**Added new variables to give more flexibility with image name and tag, so there are new instructions in the comments below**

~~Previously when running `make build` it would create a custom Drupal image with the name "projectname_drupal". This PR adds a variable to sample.env to allow setting a URL and namespace to create an image that's ready to push to dockerhub, gitlab, etc.~~

~~This also adds another make command called `make push-image` to then push that new image to dockerhub, gitlab, etc. using the same URL & namespace.~~

~~To test, change CUSTOM_DRUPAL_NAMESPACE in .env to be your dockerhub username, or your gitlab registry URL & namespace and run `make build`, then `make push-image`.~~

~~eg. 
CUSTOM_DRUPAL_NAMESPACE=dockerhub_username
CUSTOM_DRUPAL_NAMESPACE=gitlab_registry_url.com/namespace~~

~~Leaving the namespace as the default shouldn't cause any issues, but will name the image mynamespace/projectname_drupal and`make push-image` will not work with the default namespace because it just tries to push to a dockerhub namespace the user doesn't have access to.~~