### PR TITLE
Run composer commands as nginx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,11 @@ local: generate-secrets
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
 	docker-compose up -d --remove-orphans
 	@echo "Wait for the /var/www/drupal directory to be available"
-	while ! docker-compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
+	while ! docker compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
 		echo "Waiting for /var/www/drupal directory to be available..."; \
 		sleep 2; \
 	done
-	docker-compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ && su nginx -s /bin/bash -c "composer install"'
+	docker compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ && su nginx -s /bin/bash -c "composer install"'
 	$(MAKE) remove_standard_profile_references_from_config drupal-database update-settings-php ENVIRONMENT=local
 	docker compose exec -T drupal with-contenv bash -lc "drush si -y islandora_install_profile_demo --account-pass '$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)'"
 	$(MAKE) delete-shortcut-entities && docker compose exec -T drupal with-contenv bash -lc "drush pm:un -y shortcut"
@@ -193,11 +193,11 @@ starter_dev: generate-secrets
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	docker-compose up -d --remove-orphans
 		@echo "Wait for the /var/www/drupal directory to be available"
-	while ! docker-compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
+	while ! docker compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
 		echo "Waiting for /var/www/drupal directory to be available..."; \
 		sleep 2; \
 	done
-	docker-compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ && su nginx -s /bin/bash -c "composer install"'
+	docker compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ && su nginx -s /bin/bash -c "composer install"'
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 
@@ -342,7 +342,7 @@ download-default-certs:
 
 # Run Composer Update in your Drupal container
 composer_update:
-	docker-compose exec -T drupal with-contenv bash -lc su nginx -s /bin/bash -c "composer update"
+	docker compose exec -T drupal with-contenv bash -lc su nginx -s /bin/bash -c "composer update"
 
 
 reindex-fcrepo-metadata:

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ local: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
 	docker-compose up -d --remove-orphans
-	docker-compose exec -T drupal with-contenv bash -lc 'composer install; chown -R nginx:nginx .'
+	docker-compose exec -T drupal with-contenv bash -lc "su nginx -s /bin/bash -c 'composer install'; chown -R nginx:nginx ."
 	$(MAKE) remove_standard_profile_references_from_config drupal-database update-settings-php ENVIRONMENT=local
 	docker-compose exec -T drupal with-contenv bash -lc "drush si -y islandora_install_profile_demo --account-pass $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)"
 	$(MAKE) delete-shortcut-entities && docker-compose exec -T drupal with-contenv bash -lc "drush pm:un -y shortcut"
@@ -185,7 +185,7 @@ starter_dev: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	docker-compose up -d --remove-orphans
-	docker-compose exec -T drupal with-contenv bash -lc 'composer install'
+	docker-compose exec -T drupal with-contenv bash -lc "su nginx -s /bin/bash -c 'composer install'"
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 
@@ -309,7 +309,7 @@ download-default-certs:
 
 # Run Composer Update in your Drupal container
 composer_update:
-	docker-compose exec -T drupal with-contenv bash -lc 'composer update'
+	docker-compose exec -T drupal with-contenv bash -lc su nginx -s /bin/bash -c 'composer update'"
 
 
 reindex-fcrepo-metadata:

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ download-default-certs:
 
 # Run Composer Update in your Drupal container
 composer_update:
-	docker-compose exec -T drupal with-contenv bash -lc su nginx -s /bin/bash -c 'composer update'"
+	docker-compose exec -T drupal with-contenv bash -lc su nginx -s /bin/bash -c "composer update"
 
 
 reindex-fcrepo-metadata:

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,12 @@ local: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
 	docker-compose up -d --remove-orphans
-	docker-compose exec -T drupal with-contenv bash -lc "chown -R nginx:nginx . ; su nginx -s /bin/bash -c 'composer install'"
+	@echo "Wait for the /var/www/drupal directory to be available"
+	while ! docker-compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
+		echo "Waiting for /var/www/drupal directory to be available..."; \
+		sleep 2; \
+	done
+	docker-compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ && su nginx -s /bin/bash -c "composer install"'
 	$(MAKE) remove_standard_profile_references_from_config drupal-database update-settings-php ENVIRONMENT=local
 	docker compose exec -T drupal with-contenv bash -lc "drush si -y islandora_install_profile_demo --account-pass '$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)'"
 	$(MAKE) delete-shortcut-entities && docker compose exec -T drupal with-contenv bash -lc "drush pm:un -y shortcut"
@@ -187,7 +192,12 @@ starter_dev: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	docker-compose up -d --remove-orphans
-	docker-compose exec -T drupal with-contenv bash -lc "chown -R nginx:nginx . ; su nginx -s /bin/bash -c 'composer install'"
+		@echo "Wait for the /var/www/drupal directory to be available"
+	while ! docker-compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
+		echo "Waiting for /var/www/drupal directory to be available..."; \
+		sleep 2; \
+	done
+	docker-compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ && su nginx -s /bin/bash -c "composer install"'
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,8 @@ local: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
 	docker-compose up -d --remove-orphans
-	docker-compose exec -T drupal with-contenv bash -lc "su nginx -s /bin/bash -c 'composer install'; chown -R nginx:nginx ."
+	docker-compose exec --user nginx -T drupal with-contenv bash -lc "composer install"
+	docker-compose exec -T drupal with-contenv bash -lc "chown -R nginx:nginx ."
 	$(MAKE) remove_standard_profile_references_from_config drupal-database update-settings-php ENVIRONMENT=local
 	docker-compose exec -T drupal with-contenv bash -lc "drush si -y islandora_install_profile_demo --account-pass $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)"
 	$(MAKE) delete-shortcut-entities && docker-compose exec -T drupal with-contenv bash -lc "drush pm:un -y shortcut"

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ starter_dev: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	docker-compose up -d --remove-orphans
-	docker-compose exec -T drupal with-contenv bash -lc "su nginx -s /bin/bash -c 'composer install'"
+	docker-compose exec --user nginx -T drupal with-contenv bash -lc "composer install"
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 

--- a/Makefile
+++ b/Makefile
@@ -148,8 +148,7 @@ local: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
 	docker-compose up -d --remove-orphans
-	docker-compose exec --user nginx -T drupal with-contenv bash -lc "composer install"
-	docker-compose exec -T drupal with-contenv bash -lc "chown -R nginx:nginx ."
+	docker-compose exec -T drupal with-contenv bash -lc "chown -R nginx:nginx . ; su nginx -s /bin/bash -c 'composer install'"
 	$(MAKE) remove_standard_profile_references_from_config drupal-database update-settings-php ENVIRONMENT=local
 	docker-compose exec -T drupal with-contenv bash -lc "drush si -y islandora_install_profile_demo --account-pass $(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)"
 	$(MAKE) delete-shortcut-entities && docker-compose exec -T drupal with-contenv bash -lc "drush pm:un -y shortcut"
@@ -186,7 +185,7 @@ starter_dev: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	docker-compose up -d --remove-orphans
-	docker-compose exec --user nginx -T drupal with-contenv bash -lc "composer install"
+	docker-compose exec -T drupal with-contenv bash -lc "chown -R nginx:nginx . ; su nginx -s /bin/bash -c 'composer install'"
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ local: generate-secrets
 		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'git clone -b main https://github.com/islandora-devops/islandora-sandbox /tmp/codebase; mv /tmp/codebase/* /home/root;'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=local
-	docker-compose up -d --remove-orphans
+	docker compose up -d --remove-orphans
 	@echo "Wait for the /var/www/drupal directory to be available"
 	while ! docker compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
 		echo "Waiting for /var/www/drupal directory to be available..."; \
@@ -191,7 +191,7 @@ starter_dev: generate-secrets
 		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'git clone -b main https://github.com/Islandora-Devops/islandora-starter-site /home/root;'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
-	docker-compose up -d --remove-orphans
+	docker compose up -d --remove-orphans
 		@echo "Wait for the /var/www/drupal directory to be available"
 	while ! docker compose exec -T drupal with-contenv bash -lc 'test -d /var/www/drupal'; do \
 		echo "Waiting for /var/www/drupal directory to be available..."; \
@@ -431,7 +431,7 @@ ifndef DEST
 	$(error DEST is not set)
 endif
 	docker compose exec -T drupal with-contenv bash -lc 'tar zcvf /tmp/public-files.tgz -C /var/www/drupal/web/sites/default/files ${PUBLIC_FILES_TAR_DUMP_PATH}'
-	docker cp $$(docker-compose ps -q drupal):/tmp/public-files.tgz $(DEST)
+	docker cp $$(docker compose ps -q drupal):/tmp/public-files.tgz $(DEST)
 
 
 # import Drupal's public files from zipped tarball


### PR DESCRIPTION
Running composer install or update frequently causes modules to install as root. This should prevent that.