### PR TITLE
changed logic so make up won't run make demo if docker-compose up fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,9 +257,13 @@ docker-compose.yml: $(SERVICES:%=build/docker-compose/docker-compose.%.yml) .env
 
 .PHONY: up
 .SILENT: up
-## Brings up the containers or builds demo if no containers were found.
+## Brings up the containers or builds demo if no docker-compose.yml file is found.
 up:
-	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) demo
+	if [ -f docker-compose.yml ]; then \
+		docker-compose up -d --remove-orphans; \
+	else \
+		$(MAKE) demo; \
+	fi
 	@echo "\n Sleeping for 10 seconds to wait for Drupal to finish building.\n"
 	sleep 10
 	docker-compose exec -T drupal with-contenv bash -lc "for_all_sites update_settings_php"


### PR DESCRIPTION
Running `make up` is supposed to run `make demo` if there is not a docker-compose file already in place, or run `docker-compose up` otherwise

The existing logic tells it to run `make demo` if there is no docker-compose.yml OR if `docker-compose up` fails. This can cause problems if you have installed a site and then made some change that causes some of your containers to be unable to spin up. For example, if you take down your containers to update from version 1.0.10 to 1.0.11, but the pull of the new images fails.

This PR changes the logic so that if there is a docker-compose.yml file, but docker-compose up fails it will not try to install demo.

To test:
1. clone isle-dc and run `make up` to install a demo site
2. run `make down`
3. run `make up` to bring containers back up
4. run `make down`
5. change TAG variable in .env to something that doesn't exist (like 1.0.100)
6. run `make -B docker-compose.yml` to update the docker-compose with the non-existent images 
7. run `make up` to see it fail without trying to install a demo site