### PR TITLE
Starter from codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,9 +257,13 @@ docker-compose.yml: $(SERVICES:%=build/docker-compose/docker-compose.%.yml) .env
 
 .PHONY: up
 .SILENT: up
-## Brings up the containers or builds demo if no containers were found.
+## Brings up the containers or builds demo if no docker-compose.yml file is found.
 up:
-	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) demo
+	if [ -f docker-compose.yml ]; then \
+		docker-compose up -d --remove-orphans; \
+	else \
+		$(MAKE) demo; \
+	fi
 	@echo "\n Sleeping for 10 seconds to wait for Drupal to finish building.\n"
 	sleep 10
 	docker-compose exec -T drupal with-contenv bash -lc "for_all_sites update_settings_php"

--- a/Makefile
+++ b/Makefile
@@ -259,13 +259,9 @@ docker-compose.yml: $(SERVICES:%=build/docker-compose/docker-compose.%.yml) .env
 
 .PHONY: up
 .SILENT: up
-## Brings up the containers or builds demo if no docker-compose.yml file is found.
+## Brings up the containers or builds demo if no containers were found.
 up:
-	if [ -f docker-compose.yml ]; then \
-		docker-compose up -d --remove-orphans; \
-	else \
-		$(MAKE) demo; \
-	fi
+	test -f docker-compose.yml && docker-compose up -d --remove-orphans || $(MAKE) demo
 	@echo "\n Sleeping for 10 seconds to wait for Drupal to finish building.\n"
 	sleep 10
 	docker-compose exec -T drupal with-contenv bash -lc "for_all_sites update_settings_php"

--- a/Makefile
+++ b/Makefile
@@ -163,12 +163,14 @@ local: generate-secrets
 
 
 .PHONY: starter
-## Make a local site with codebase directory bind mounted, using starter site.
+## Make a local site with codebase directory bind mounted, using starter site unless other package specified in .env or present already.
 starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project islandora/islandora-starter-site:dev-main /tmp/codebase; mv /tmp/codebase/* /home/root;'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase; mv /tmp/codebase/* /home/root;'; \
+	else \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root; composer install'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	docker-compose up -d --remove-orphans

--- a/sample.env
+++ b/sample.env
@@ -32,6 +32,10 @@ DOCKER_BUILDKIT=1
 # Dockerfile to use when building the custom project.
 PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 
+# Packagist repo to use when creating a site with make starter
+# Change this if you want to build from a different codebase than the starter site
+CODEBASE_PACKAGE=islandora/islandora-starter-site:dev-main
+
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.
 INCLUDE_TRAEFIK_SERVICE=true


### PR DESCRIPTION
Added ability to make starter with a different codebase.

In .env we can change the Packagist repo to something other than the starter site, or we can clone our own codebase folder and run `make starter` from that.

To test:
1. Run `make starter` as normal to get fresh starter site
2. `make clean`
3. Change the CODEBASE_PACKAGE variable in .env to another Packagist repo and run `make starter` to get a fresh install from that repo instead of the starter site
4. `make clean`
5. Put your own codebase folder in the isle-dc directory and run `make starter`. Instead of trying to pull from packagist it will just copy that into the container and run composer install