### PR TITLE
added cache rebuild to database import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,6 +397,7 @@ endif
 	docker cp "$(SRC)" $$(docker-compose ps -q drupal):/tmp/dump.sql
 	# Need to specify the root user to import the database otherwise it will fail due to permissions.
 	docker-compose exec -T drupal with-contenv bash -lc 'chown root:root /tmp/dump.sql && mysql -u $${DRUPAL_DEFAULT_DB_ROOT_USER} -p$${DRUPAL_DEFAULT_DB_ROOT_PASSWORD} -h $${DRUPAL_DEFAULT_DB_HOST} $${DRUPAL_DEFAULT_DB_NAME} < /tmp/dump.sql'
+	docker-compose exec -T drupal with-contenv bash -lc 'drush cache-rebuild'
 
 
 .PHONY: config-export


### PR DESCRIPTION
Running the database import command often messes up the site layout until the Drupal cache is cleared (looks like a CSS cache issue). This adds the drush command for clearing the cache to the database import process.

I'm not sure how to reliably trigger the need for the cache rebuild, because it doesn't seem to happen every time, but I have had it happen multiple times when importing the database from my production site to my local dev copy.
