### PR TITLE
fix for public file export path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,7 @@ drupal-public-files-dump:
 ifndef DEST
 	$(error DEST is not set)
 endif
-	docker-compose exec -T drupal with-contenv bash -lc 'tar zcvf /tmp/public-files.tgz /var/www/drupal/web/sites/default/files'
+	docker-compose exec -T drupal with-contenv bash -lc 'tar zcvf /tmp/public-files.tgz -C /var/www/drupal/web/sites/default/files .'
 	docker cp $$(docker-compose ps -q drupal):/tmp/public-files.tgz $(DEST)
 
 

--- a/Makefile
+++ b/Makefile
@@ -418,7 +418,7 @@ drupal-public-files-dump:
 ifndef DEST
 	$(error DEST is not set)
 endif
-	docker-compose exec -T drupal with-contenv bash -lc 'tar zcvf /tmp/public-files.tgz -C /var/www/drupal/web/sites/default/files .'
+	docker-compose exec -T drupal with-contenv bash -lc 'tar zcvf /tmp/public-files.tgz -C /var/www/drupal/web/sites/default/files ${PUBLIC_FILES_TAR_DUMP_PATH}'
 	docker cp $$(docker-compose ps -q drupal):/tmp/public-files.tgz $(DEST)
 
 

--- a/sample.env
+++ b/sample.env
@@ -197,3 +197,9 @@ WATCHTOWER_MEMORY_LIMIT=2G
 CANTALOUPE_DELEGATE_SCRIPT_ENABLED=false
 CANTALOUPE_DELEGATE_SCRIPT_PATHNAME=/opt/tomcat/bin/delegates.rb
 CANTALOUPE_HTTPSOURCE_LOOKUP_STRATEGY=BasicLookupStrategy
+
+# Path to include in tar file for exported public files
+# If set to . the files will be exported wherever you specify as DEST
+#   when running make drupal-public-files-import
+# If set to anything else, that path will be added to DEST
+PUBLIC_FILES_TAR_DUMP_PATH=.


### PR DESCRIPTION
When exporting the public files directory the tar was being created with the path /var/www/drupal/web/sites/default/files, and then when that dump was imported, it would be placed back at that location and duplicate the path. This meant files are being placed at /var/www/drupal/web/sites/default/files/var/www/drupal/web/sites/default/files.

This PR changes the path inside the exported dump to be ./ which will allow us to extract the files wherever we want.

To reproduce the issue:
- Install a fresh starter site with `make starter`
- check the files directory with `docker-compose exec drupal with-contenv bash -lc 'ls /var/www/drupal/web/sites/default/files'`
- `make drupal-public-files-dump DEST=files.tgz`
- `make drupal-public-files-import SRC=files.tgz`
- `docker-compose exec drupal with-contenv bash -lc 'ls /var/www/drupal/web/sites/default/files'` again
You should see that you now have your files duplicated at /var/www/drupal/web/sites/default/files/var/www/drupal/web/sites/default/files

To test this PR works:
- add something to the files directory with `docker-compose exec drupal with-contenv bash -lc 'touch /var/www/drupal/web/sites/default/files/test.txt'`
- `docker-compose exec drupal with-contenv bash -lc 'ls /var/www/drupal/web/sites/default/files'`
- `make drupal-public-files-dump DEST=files.tgz`
- remove the file with `docker-compose exec drupal with-contenv bash -lc 'rm /var/www/drupal/web/sites/default/files/test.txt'`
- `docker-compose exec drupal with-contenv bash -lc 'ls /var/www/drupal/web/sites/default/files'`
- `make drupal-public-files-import SRC=files.tgz`
- `docker-compose exec drupal with-contenv bash -lc 'ls /var/www/drupal/web/sites/default/files'`
You should see that your file was added back to the correct location from the import 
