### PR TITLE
added db host and port for mysql to docker-compose.drupal.mariadb.yml

### DIFF
--- a/build/docker-compose/docker-compose.drupal.mariadb.yml
+++ b/build/docker-compose/docker-compose.drupal.mariadb.yml
@@ -4,3 +4,5 @@ services:
   drupal:
     environment:
       DRUPAL_DEFAULT_DB_DRIVER: mysql
+      DRUPAL_DEFAULT_DB_HOST: mariadb
+      DRUPAL_DEFAULT_DB_PORT: ${MYSQL_PORT}


### PR DESCRIPTION
This PR adds the DRUPAL_DEFAULT_DB_HOST and DRUPAL_DEFAULT_DB_PORT environment variables to the Drupal container when using mariadb.

Previously these were populated when the container spins up, as described in the README for Drupal and the base image:
"The default value is derived from `DB_DRIVER` if not specified"

This caused an issue for me where running `make up` would wait 10 seconds then run `make update-settings-php` but those values had not been derived yet. This caused my settings.php file to be populated correctly, except for
```
$databases['default']['default']['host'] = 'mariadb';
$databases['default']['default']['port'] = '3306';
```
which were both blank.

If I changed the wait from 10 to 30 seconds it would work, but by specifying it in the docker-compose file it removes the risk of these being blank because they are now specified as environment variables when starting the container.

This might be hard to test, because it only happened to me on a production environment where settings.php is created when the site is spun up and is not part of the image. It should be easy to test that it doesn't hurt anything though.
