### PR TITLE
Update make build to specify platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ build:
 	if [ ! -f $(PROJECT_DRUPAL_DOCKERFILE) ]; then \
 		cp "$(CURDIR)/sample.Dockerfile" $(PROJECT_DRUPAL_DOCKERFILE); \
 	fi
-	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t $(CUSTOM_IMAGE_NAMESPACE)/$(CUSTOM_IMAGE_NAME):${CUSTOM_IMAGE_TAG} --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) .
+	docker build -f $(PROJECT_DRUPAL_DOCKERFILE) -t $(CUSTOM_IMAGE_NAMESPACE)/$(CUSTOM_IMAGE_NAME):${CUSTOM_IMAGE_TAG} --build-arg REPOSITORY=$(REPOSITORY) --build-arg TAG=$(TAG) --platform linux/amd64 .
 
 
 .PHONY: push-image


### PR DESCRIPTION
When building on an M1/M2 mac the default is to build for arm64 instead of amd64 which causes issues when trying to run a custom drupal image.

This PR specifies the image so that `make build` can be run on an M1/M2 mac. 

To test, run `make build` to create a custom drupal image, then test that the image doesn't throw errors when starting. Without this PR on an M1/M2 mac the drupal container will continually restart.