### PR TITLE
remove recast

### DIFF
--- a/build/docker-compose/docker-compose.crayfish.yml
+++ b/build/docker-compose/docker-compose.crayfish.yml
@@ -46,12 +46,3 @@ services:
             memory: ${MILLINER_MEMORY_LIMIT:-1G}
           reservations:
             memory: 512M
-  recast:
-    restart: ${RESTART_POLICY:-unless-stopped}
-    image: ${REPOSITORY:-islandora}/recast:${TAG:-latest}
-    deploy:
-      resources:
-          limits:
-            memory: ${RECAST_MEMORY_LIMIT:-1G}
-          reservations:
-            memory: 512M

--- a/build/docker-compose/docker-compose.secrets.yml
+++ b/build/docker-compose/docker-compose.secrets.yml
@@ -83,7 +83,3 @@ services:
     secrets:
       - JWT_ADMIN_TOKEN
       - JWT_PUBLIC_KEY
-  recast:
-    secrets:
-      - JWT_ADMIN_TOKEN
-      - JWT_PUBLIC_KEY


### PR DESCRIPTION
Closes https://github.com/Islandora-Devops/isle-dc/issues/299

`make starter TAG=2.0.0` is failing with

```
Error response from daemon: manifest for islandora/recast:2.0.0 not found: manifest unknown: manifest unknown
```
 
See https://github.com/Islandora-Devops/isle-buildkit/issues/220 for additional discussion around removing recast. It was removed from `isle-buildkit` with https://github.com/Islandora-Devops/isle-buildkit/pull/238

With this PR `make starter TAG=2.0.0` builds OK.