### PR TITLE
Fix php-fpm PID check for php8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,11 @@ CMD := $(shell [ $(IS_DRUPAL_PSSWD_FILE_READABLE) -eq 1 ] && echo 'tee' || echo 
 
 LATEST_VERSION := $(shell curl -s https://api.github.com/repos/desandro/masonry/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/')
 
+PHP_FPM_PID=/var/run/php-fpm7/php-fpm7.pid
+ifeq ($(shell expr $(TAG) \>= 2.0), 1)
+	PHP_FPM_PID=/var/run/php-fpm81/php-fpm81.pid
+endif
+
 #############################################
 ## Default Rule                            ##
 #############################################
@@ -525,7 +530,7 @@ remove_standard_profile_references_from_config:
 ## Creates required databases for drupal site(s) using environment variables.
 .SILENT: drupal-database
 drupal-database:
-	docker compose exec -T drupal timeout 300 bash -c "while ! test -e /var/run/nginx/nginx.pid -a -e /var/run/php-fpm7/php-fpm7.pid; do sleep 1; done"
+	docker compose exec -T drupal timeout 300 bash -c "while ! test -e /var/run/nginx/nginx.pid -a -e $(PHP_FPM_PID); do echo 'Waiting for nginx and php-fpm'; sleep 1; done"
 	docker compose exec -T drupal with-contenv bash -lc "for_all_sites create_database"
 
 

--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=1.0.10
+TAG=2.0.1
 
 ###############################################################################
 # Exposed Containers & Ports

--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:0.8.0
+CODEBASE_PACKAGE=islandora/islandora-starter-site:1.1.0
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.

--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=2.0.1
+TAG=2.0.2
 
 ###############################################################################
 # Exposed Containers & Ports

--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=2.0.2
+TAG=2.0.3
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
## Summary

`make drupal-database` during `make starter TAG=2.0.0` hangs while waiting to find the php-fpm PID file, which is in a new location on php 8.1. This PR updates the check to work for php 8.1, and updates the buildkit and starter site tags to use php 8.1 and drupal 10.

## How to test

First, https://github.com/Islandora-Devops/isle-dc/pull/346 needs to merge and this branch needs rebased.

### Checkout this PR

```
cd /path/to/your/isle-dev/copy
gh pr checkout 347 --repo Islandora-Devops/isle-dc
```

### Make sure php 8.1 + drupal 10 comes up
```
make starter
curl -v https://islandora.traefik.me/ > /dev/null
```
