### PR TITLE
specify starter site version in sample.env

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:dev-main
+CODEBASE_PACKAGE=islandora/islandora-starter-site:0.8.0
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.


### PR DESCRIPTION
starter site needs to be installed at version 0.8.0 in order to be compatible with Isle 1.0.10.

Once we are ready to bump the default TAG to 2.0.0 or higher we will need to bump starter site as well to get Drupal 10.

