### PR TITLE
Bump isle-buildkit TAG to 2.0.4

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=2.0.3
+TAG=2.0.4
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
2.0.4 resolves an issue with hypercube not generating OCR or hOCR for TIFF or JP2

https://github.com/Islandora-Devops/isle-buildkit/pull/292