### PR TITLE
Add php 8.2 // isle-buildkit:3.x support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,9 @@ CMD := $(shell [ $(IS_DRUPAL_PSSWD_FILE_READABLE) -eq 1 ] && echo 'tee' || echo 
 LATEST_VERSION := $(shell curl -s https://api.github.com/repos/desandro/masonry/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/')
 
 PHP_FPM_PID=/var/run/php-fpm7/php-fpm7.pid
-ifeq ($(shell expr $(TAG) \>= 2.0), 1)
+ifeq ($(shell expr $(TAG) \>= 3.0), 1)
+	PHP_FPM_PID=/var/run/php-fpm82/php-fpm82.pid
+else ifeq ($(shell expr $(TAG) \>= 2.0), 1)
 	PHP_FPM_PID=/var/run/php-fpm81/php-fpm81.pid
 endif
 

--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:1.1.0
+CODEBASE_PACKAGE=islandora/islandora-starter-site:1.2.0
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=2.0.4
+TAG=2.0.10
 
 ###############################################################################
 # Exposed Containers & Ports

--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=2.0.10
+TAG=3.0.0
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
## Summary

https://github.com/Islandora-Devops/isle-buildkit/pull/299 bumped the isle-buildkit major version from `2.x` to `3.x` since that PR upgraded PHP `8.1 -> 8.2`, and 8.2 could break drupal 9 sites. This PR simply checks if the tag is 3.x and sets the PHP FPM pid file to the correct value. It also bumps the starter site and default isle-buildkit tags to the latest versions.

## Testing

### New functionality

Running this command (which will destroy any site you may have running locally) spins up a d10 site with php 8.2

```
make down clean
make starter TAG=3.0.0
```

### Regression test

Running this command (which will destroy any site you may have running locally) spins up a d10 site with php 8.1

```
make down clean
make starter TAG=2.0.10
```