### PR TITLE
added new make commands for importing and exporting in fedora 6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -420,13 +420,32 @@ fcrepo-export:
 ifndef DEST
 	$(error DEST is not set)
 endif
+	docker compose exec -T fcrepo with-contenv bash -lc 'tar zcvf fcrepo-export.tgz -C /data/home/data/ocfl-root/ .'
+	docker compose exec -T fcrepo with-contenv bash -lc 'mv fcrepo-export.tgz /tmp'
+	docker cp $$(docker compose ps -q fcrepo):/tmp/fcrepo-export.tgz $(DEST)
+
+
+# Import fcrepo from zipped tarball
+fcrepo-import: $(SRC)
+ifndef SRC
+	$(error SRC is not set)
+endif
+	docker cp "$(SRC)" $$(docker compose ps -q fcrepo):/tmp/fcrepo-export.tgz
+	docker compose exec -T fcrepo with-contenv bash -lc 'tar zxvf /tmp/fcrepo-export.tgz -C /data/home/data/ocfl-root/ && chown -R tomcat:tomcat /data/home/data/ocfl-root/ && rm /tmp/fcrepo-export.tgz'
+
+
+# Dump fcrepo as zipped tarball
+fcrepo5-export:
+ifndef DEST
+	$(error DEST is not set)
+endif
 	docker compose exec -T fcrepo with-contenv bash -lc 'java -jar /opt/tomcat/fcrepo-import-export-1.0.1.jar --mode export -r http://$(DOMAIN):8081/fcrepo/rest -d /tmp/fcrepo-export -b -u $${FCREPO_TOMCAT_ADMIN_USER}:$${FCREPO_TOMCAT_ADMIN_PASSWORD}'
 	docker compose exec -T fcrepo with-contenv bash -lc 'cd /tmp && tar zcvf fcrepo-export.tgz fcrepo-export'
 	docker cp $$(docker compose ps -q fcrepo):/tmp/fcrepo-export.tgz $(DEST)
 
 
 # Import fcrepo from zipped tarball
-fcrepo-import: $(SRC)
+fcrepo5-import: $(SRC)
 ifndef SRC
 	$(error SRC is not set)
 endif

--- a/Makefile
+++ b/Makefile
@@ -431,7 +431,10 @@ ifndef SRC
 	$(error SRC is not set)
 endif
 	docker cp "$(SRC)" $$(docker compose ps -q fcrepo):/tmp/fcrepo-export.tgz
+	docker compose exec -T fcrepo with-contenv bash -lc 'rm -r /data/home/data/ocfl-root/*'
 	docker compose exec -T fcrepo with-contenv bash -lc 'tar zxvf /tmp/fcrepo-export.tgz -C /data/home/data/ocfl-root/ && chown -R tomcat:tomcat /data/home/data/ocfl-root/ && rm /tmp/fcrepo-export.tgz'
+	docker compose exec -T mariadb with-contenv bash -lc 'mysql -e "drop database fcrepo;"'
+	docker compose restart fcrepo
 
 
 # Dump fcrepo as zipped tarball


### PR DESCRIPTION
Added new make commands for importing and exporting in fedora 6, and renamed the old commands to fcrepo5-import and fcrepo5-export

This should resolve https://github.com/Islandora-Devops/isle-dc/issues/368

In fedora 6 we don't need to run any import or export utilities, we just need to copy the /data/home/data/ocfl-root directory. The new commands do that, in the same way we copy our public files directory. For anyone still using fedora 5, they can use the old commands, which have been renamed to fedora5-export and fedora5-import.

To test the new commands:
1. add some Islandora objects to a site
2. do an export with `make fcrepo-export`
3. remove your fcrepo volume
4. restart the fcrepo container
5. do an import with `make fcrepo-import`