### PR TITLE
374-update-images Update to BuildKit images 3.1.

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=3.0.0
+TAG=3.1.0
 
 ###############################################################################
 # Exposed Containers & Ports

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,6 @@
 # Environment variables defined in this file apply to both the Makefile and to
 # docker-compose.yml
-# 
+#
 # Due to restrictions in the `env-file` format we cannot specify multi-line
 # values for environment variables. For this reason the environment
 # variables are set on service definitions in the docker-compose.*.yml files,
@@ -38,7 +38,7 @@ PROJECT_DRUPAL_DOCKERFILE=Dockerfile
 CUSTOM_IMAGE_NAMESPACE=mynamespace
 
 # Image name of custom drupal image
-# This is used when pulling a custom image for environments set to custom and 
+# This is used when pulling a custom image for environments set to custom and
 # when building a custom image with make build
 CUSTOM_IMAGE_NAME=${COMPOSE_PROJECT_NAME}_drupal
 
@@ -87,14 +87,14 @@ DRUPAL_DATABASE_SERVICE=mariadb
 FCREPO_DATABASE_SERVICE=mariadb
 
 # Repository to use for pulling isle-buildkit images, change to `local`
-# To use images you have built locally with isle-buildkit, or use your 
+# To use images you have built locally with isle-buildkit, or use your
 # custom docker registry if you have set up one.
 #
 REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=3.1.0
+TAG=3.1.3
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
This was suggested in the last tech call for getting JP2 support to work out of the box.

I've tested it and I can now upload JP2s and they appear in Mirador.

![image](https://github.com/Islandora-Devops/isle-dc/assets/82412/ea31614d-a777-4b9d-90fe-78c29a679f4e)


To test simply build with 'make starter' or 'make starter_dev', then create a new Repository Item object, and give it the model "Paged Content."

Then go to the Children tab, and choose 'Bulk add children".

On the next page, choose Repository Item for the content type, 'Page' for the model, 'File' for the media type and 'Original File' for the media use tag.

Then on the neext page, upload one or more JP2 files and click 'Finish.

When you go back to the node's View tab, the pages should appear in the Mirador viewer.