### PR TITLE
Update to BuildKit images v. 3.1.4.

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=3.1.3
+TAG=3.1.4
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
This incorporates the bugfix that was breaking Hypercube.

Tested by running 'make starter_dev' from a clean install.

