### PR TITLE
Updated network option

### DIFF
--- a/build/docker-compose/docker-compose.activemq.yml
+++ b/build/docker-compose/docker-compose.activemq.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   activemq-data:
 services:

--- a/build/docker-compose/docker-compose.activemq.yml
+++ b/build/docker-compose/docker-compose.activemq.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   activemq-data:
 services:

--- a/build/docker-compose/docker-compose.blazegraph.yml
+++ b/build/docker-compose/docker-compose.blazegraph.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   blazegraph-data:
 services:

--- a/build/docker-compose/docker-compose.blazegraph.yml
+++ b/build/docker-compose/docker-compose.blazegraph.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   blazegraph-data:
 services:

--- a/build/docker-compose/docker-compose.cantaloupe.yml
+++ b/build/docker-compose/docker-compose.cantaloupe.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   cantaloupe-data:
 services:

--- a/build/docker-compose/docker-compose.cantaloupe.yml
+++ b/build/docker-compose/docker-compose.cantaloupe.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   cantaloupe-data:
 services:

--- a/build/docker-compose/docker-compose.code-server.yml
+++ b/build/docker-compose/docker-compose.code-server.yml
@@ -6,8 +6,6 @@ version: '3.7'
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 secrets:
   CODE_SERVER_PASSWORD:
     file: "../../secrets/live/CODE_SERVER_PASSWORD"

--- a/build/docker-compose/docker-compose.code-server.yml
+++ b/build/docker-compose/docker-compose.code-server.yml
@@ -7,7 +7,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 secrets:
   CODE_SERVER_PASSWORD:
     file: "../../secrets/live/CODE_SERVER_PASSWORD"

--- a/build/docker-compose/docker-compose.crayfish.yml
+++ b/build/docker-compose/docker-compose.crayfish.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 services:
   homarus:
     restart: ${RESTART_POLICY:-unless-stopped}

--- a/build/docker-compose/docker-compose.crayfish.yml
+++ b/build/docker-compose/docker-compose.crayfish.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 services:
   homarus:
     restart: ${RESTART_POLICY:-unless-stopped}

--- a/build/docker-compose/docker-compose.custom.yml
+++ b/build/docker-compose/docker-compose.custom.yml
@@ -4,7 +4,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.custom.yml
+++ b/build/docker-compose/docker-compose.custom.yml
@@ -3,8 +3,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.demo.yml
+++ b/build/docker-compose/docker-compose.demo.yml
@@ -9,7 +9,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.demo.yml
+++ b/build/docker-compose/docker-compose.demo.yml
@@ -9,8 +9,7 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
+
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.demo.yml
+++ b/build/docker-compose/docker-compose.demo.yml
@@ -10,7 +10,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.drupal.yml
+++ b/build/docker-compose/docker-compose.drupal.yml
@@ -3,8 +3,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 services:
   # The service name is drupal that is the default host name used by micro-services etc.
   # Needs to match against demo, custom, and local.

--- a/build/docker-compose/docker-compose.drupal.yml
+++ b/build/docker-compose/docker-compose.drupal.yml
@@ -4,7 +4,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 services:
   # The service name is drupal that is the default host name used by micro-services etc.
   # Needs to match against demo, custom, and local.

--- a/build/docker-compose/docker-compose.fcrepo.yml
+++ b/build/docker-compose/docker-compose.fcrepo.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   fcrepo-data:
 services:

--- a/build/docker-compose/docker-compose.fcrepo.yml
+++ b/build/docker-compose/docker-compose.fcrepo.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   fcrepo-data:
 services:

--- a/build/docker-compose/docker-compose.fcrepo6.yml
+++ b/build/docker-compose/docker-compose.fcrepo6.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   fcrepo-data:
 services:

--- a/build/docker-compose/docker-compose.fcrepo6.yml
+++ b/build/docker-compose/docker-compose.fcrepo6.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   fcrepo-data:
 services:

--- a/build/docker-compose/docker-compose.local.yml
+++ b/build/docker-compose/docker-compose.local.yml
@@ -9,7 +9,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.local.yml
+++ b/build/docker-compose/docker-compose.local.yml
@@ -8,8 +8,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.matomo.yml
+++ b/build/docker-compose/docker-compose.matomo.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   matomo-config-data:
 services:

--- a/build/docker-compose/docker-compose.matomo.yml
+++ b/build/docker-compose/docker-compose.matomo.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   matomo-config-data:
 services:

--- a/build/docker-compose/docker-compose.solr.yml
+++ b/build/docker-compose/docker-compose.solr.yml
@@ -2,8 +2,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 services:
   solr:
     restart: ${RESTART_POLICY:-unless-stopped}

--- a/build/docker-compose/docker-compose.solr.yml
+++ b/build/docker-compose/docker-compose.solr.yml
@@ -3,7 +3,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 services:
   solr:
     restart: ${RESTART_POLICY:-unless-stopped}

--- a/build/docker-compose/docker-compose.starter.yml
+++ b/build/docker-compose/docker-compose.starter.yml
@@ -9,7 +9,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.starter.yml
+++ b/build/docker-compose/docker-compose.starter.yml
@@ -8,8 +8,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.starter_dev.yml
+++ b/build/docker-compose/docker-compose.starter_dev.yml
@@ -9,7 +9,7 @@ networks:
   default:
     internal: true
   gateway:
-    external: true
+    internal: false
 volumes:
   drupal-sites-data:
   solr-data:

--- a/build/docker-compose/docker-compose.starter_dev.yml
+++ b/build/docker-compose/docker-compose.starter_dev.yml
@@ -8,8 +8,6 @@ version: "3.7"
 networks:
   default:
     internal: true
-  gateway:
-    internal: false
 volumes:
   drupal-sites-data:
   solr-data:


### PR DESCRIPTION
This relates to [issue 379](https://github.com/Islandora-Devops/isle-dc/issues/379).
External is not a recognized Docker network option, but it only fails on some machines.  This ought to work anywhere, but its only been tested on a Mac, and an old one at that,
