### PR TITLE
Fix make starter and add nightly build check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
     - cron: '15 12 * * *'
 jobs:
   make:
+    environment:
+      TERM: xterm-256color
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
@@ -74,3 +76,12 @@ jobs:
             echo "Failed to bring up site"
             exit 1
           fi
+
+      - name: Notify Slack on nightly test failure
+        if: failure() && github.event_name == 'schedule'
+        run: |-
+          curl -s -o /dev/null -XPOST $SLACK_WEBHOOK_URL -d '{
+            "text": "🚨 Scheduled job failed! Click to view the run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions Run>",
+          }'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        # TODO: someone with more windows chops please add windows test support
+        # os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,12 +25,14 @@ jobs:
         run: |
           choco install mingw -y
           echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
-          
+          cp sample.env .env <-- do not know what windows cp. COPY?
           C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes
 
       - name: init secrets
         if: matrix.os != 'windows-latest'
-        run: ./build/scripts/check-secrets.sh yes
+        run: |-
+          cp sample.env .env
+          ./build/scripts/check-secrets.sh yes
         shell: bash
 
       - name: make starter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,70 @@
+name: Test
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+  schedule:
+    # UTC
+    - cron: '15 12 * * *'
+jobs:
+  make:
+    permissions:
+      contents: read
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set make and secrets for Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install mingw -y
+          echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
+          
+          C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes
+
+      - name: init secrets
+        if: matrix.os != 'windows-latest'
+        run: ./build/scripts/check-secrets.sh yes
+        shell: bash
+
+      - name: make starter
+        run: make starter
+        shell: bash
+
+      - name: check online
+        # TODO: what's a windows curl?
+        if: matrix.os != 'windows-latest'
+        run: |-
+          STATUS=$(curl -k \
+            -w '%{http_code}' -o /dev/null \
+            https://islandora.traefik.me/)
+          echo "Site check returned ${STATUS}"
+          if [ ${STATUS} -ne 200 ]; then
+            echo "Failed to bring up site"
+            exit 1
+          fi
+
+      - name: make build
+        run: make build
+        shell: bash
+
+      - name: make production
+        run: make production
+        shell: bash
+
+      - name: check online
+        # TODO: what's a windows curl?
+        if: matrix.os != 'windows-latest'
+        run: |-
+          STATUS=$(curl -k \
+            -w '%{http_code}' -o /dev/null \
+            https://islandora.traefik.me/)
+          echo "Site check returned ${STATUS}"
+          if [ ${STATUS} -ne 200 ]; then
+            echo "Failed to bring up site"
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ on:
   schedule:
     # UTC
     - cron: '15 12 * * *'
+env:
+  TERM: xterm-256color
 jobs:
   make:
-    environment:
-      TERM: xterm-256color
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,9 @@ jobs:
       matrix:
         # TODO: someone with more windows chops please add windows test support
         # os: [windows-latest, ubuntu-latest, macos-latest]
-        os: [ubuntu-latest, macos-latest]
+        # TODO: figure out how to install docker in a mac runner :facepalm:
+        # os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         # TODO: someone with more windows chops please add windows test support
         # os: [windows-latest, ubuntu-latest, macos-latest]
         # TODO: keep an eye when macos-14+ (M1) support is available
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,10 +30,6 @@ jobs:
           echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
           cp sample.env .env <-- do not know what windows cp. COPY?
           C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes
-
-      - name: Setup docker for mac
-        if: matrix.os == 'macos-13'
-        uses: douglascamata/setup-docker-macos-action@v1-alpha
 
       - name: init secrets
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,23 @@ jobs:
       matrix:
         # TODO: someone with more windows chops please add windows test support
         # os: [windows-latest, ubuntu-latest, macos-latest]
-        # TODO: figure out how to install docker in a mac runner :facepalm:
-        # os: [ubuntu-latest, macos-latest]
-        os: [ubuntu-latest]
+        # TODO: keep an eye when macos-14+ (M1) support is available
+        os: [ubuntu-latest, macos-13]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set make and secrets for Windows
+      - name: Setup make and secrets for Windows
         if: matrix.os == 'windows-latest'
         run: |
           choco install mingw -y
           echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
           cp sample.env .env <-- do not know what windows cp. COPY?
           C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes
+
+      - name: Setup docker for mac
+        if: matrix.os == 'macos-13'
+        uses: douglascamata/setup-docker-macos-action@v1-alpha
 
       - name: init secrets
         if: matrix.os != 'windows-latest'

--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:1.2.0
+CODEBASE_PACKAGE=islandora/islandora-starter-site:1.6.2
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.


### PR DESCRIPTION
Resolves #380 #357
Also tested `make starter_dev` on this PR and it successfully builds so think this also resolves #354

## Before

```
make clean
make starter
```

Fails with

```
s6-envdir: fatal: unable to envdir /run/s6/container_environment: No such file or directory
```

## After

```
make clean
make starter
```

Successfully builds

## Tests

Also added a test on pushes to this repo to ensure `make starter build production` work. Added a nightly build to also perform the check and send failure notifications to `#bots` in Islandora Slack