### PR TITLE
Add Windows test support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup make and secrets for Windows
+      - name: Setup make
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
-          cp sample.env .env
-          ./build/scripts/check-secrets.sh yes
+          echo "Not sure if make will be available or not"
+          make help
 
       - name: init secrets
         if: matrix.os != 'windows-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
           docker system info
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
+          curl -s "https://gist.githubusercontent.com/joecorall/83f521d3ef23e50317d1948a3357ce4c/raw/05e2995b338b29faee25fe946b37198741bdf62b/Dockerfile.bind-less" -o base/Dockerfile
           make bake TAGS=3.2.1
 
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,7 @@ jobs:
         shell: bash
         run: |
           # we obviously don't want to do this here, just want to see if it builds
-          curl "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o C:\ProgramData\Docker\cli-plugins\docker-buildx
-          docker buildx install
+          curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "C:\ProgramData\Docker\cli-plugins\docker-buildx.exe"
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
           make bake TAGS=3.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,15 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup make
-        if: matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          echo "Not sure if make will be available or not"
-          make help
-
       - name: init secrets
-        if: matrix.os != 'windows-latest'
         run: |-
           cp sample.env .env
           ./build/scripts/check-secrets.sh yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ on:
     - cron: '15 12 * * *'
 env:
   TERM: xterm-256color
-  DOCKER_DEFAULT_PLATFORM: linux/amd64
 jobs:
   make:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,10 @@ jobs:
 
       - name: Setup make and secrets for Windows
         if: matrix.os == 'windows-latest'
+        shell: bash
         run: |
-          choco install mingw -y
-          ls -l C:\ProgramData\mingw64\mingw64\bin
-          echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
           cp sample.env .env
-          C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes
+          ./build/scripts/check-secrets.sh yes
 
       - name: init secrets
         if: matrix.os != 'windows-latest'
@@ -42,6 +40,7 @@ jobs:
         shell: bash
 
       - name: check online
+        shell: bash
         run: |-
           STATUS=$(curl -k \
             -w '%{http_code}' -o /dev/null \
@@ -61,6 +60,7 @@ jobs:
         shell: bash
 
       - name: check online
+        shell: bash
         run: |-
           STATUS=$(curl -k \
             -w '%{http_code}' -o /dev/null \
@@ -72,6 +72,7 @@ jobs:
           fi
 
       - name: Notify Slack on nightly test failure
+        shell: bash
         if: failure() && github.event_name == 'schedule'
         run: |-
           curl -s -o /dev/null -XPOST $SLACK_WEBHOOK_URL -d '{

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Set up Docker Buildx
         if: matrix.os == 'windows-latest'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
       - name: make build
         if: matrix.os == 'windows-latest'
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,18 @@ jobs:
         # TODO: keep an eye when macos-14+ (M1) docker support is available
         os: [windows-latest, ubuntu-latest]
     steps:
+      - name: Set up Docker Buildx
+        if: matrix.os == 'windows-latest'
+        uses: docker/setup-buildx-action@v3
+      - name: make build
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          # we obviously don't want to do this here, just want to see if it builds
+          git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
+          cd /tmp/ibk
+          make bake TAGS=3.2.1
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           choco install mingw -y
+          ls -l C:\ProgramData\mingw64\mingw64\bin
           echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
           cp sample.env .env
           C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,9 @@ jobs:
           docker system info
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
-          curl -s "https://gist.githubusercontent.com/joecorall/83f521d3ef23e50317d1948a3357ce4c/raw/05e2995b338b29faee25fe946b37198741bdf62b/Dockerfile.bind-less" -o base/Dockerfile
-          make bake TAGS=3.2.1
+          rm /tmp/ibk/base/Dockerfile
+          curl -s "https://gist.githubusercontent.com/joecorall/83f521d3ef23e50317d1948a3357ce4c/raw/05e2995b338b29faee25fe946b37198741bdf62b/Dockerfile.bind-less" -o /tmp/ibk/base/Dockerfile
+          make bake TAGS=3.2.1 TARGET=drupal
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
     - cron: '15 12 * * *'
 env:
   TERM: xterm-256color
+  DOCKER_DEFAULT_PLATFORM: linux/amd64
 jobs:
   make:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # TODO: someone with more windows chops please add windows test support
-        # os: [windows-latest, ubuntu-latest, macos-latest]
-        # TODO: keep an eye when macos-14+ (M1) support is available
-        os: [ubuntu-latest]
+        # TODO: keep an eye when macos-14+ (M1) docker support is available
+        os: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -28,7 +26,7 @@ jobs:
         run: |
           choco install mingw -y
           echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" >> $GITHUB_PATH
-          cp sample.env .env <-- do not know what windows cp. COPY?
+          cp sample.env .env
           C:\Program Files\Git\bin\bash.exe ./build/scripts/check-secrets.sh yes
 
       - name: init secrets
@@ -43,8 +41,6 @@ jobs:
         shell: bash
 
       - name: check online
-        # TODO: what's a windows curl?
-        if: matrix.os != 'windows-latest'
         run: |-
           STATUS=$(curl -k \
             -w '%{http_code}' -o /dev/null \
@@ -64,8 +60,6 @@ jobs:
         shell: bash
 
       - name: check online
-        # TODO: what's a windows curl?
-        if: matrix.os != 'windows-latest'
         run: |-
           STATUS=$(curl -k \
             -w '%{http_code}' -o /dev/null \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,11 @@ jobs:
         shell: bash
         run: |
           # we obviously don't want to do this here, just want to see if it builds
-          printenv
           mkdir -p "/c/Users/runneradmin/.docker/cli-plugins"
           export PATH="$PATH:/c/Users/runneradmin/.docker/cli-plugins"
           curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "/c/Users/runneradmin/.docker/cli-plugins/docker-buildx.exe"
           ls -l /c/Users/runneradmin/.docker/cli-plugins
+          docker system info
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
           make bake TAGS=3.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,9 @@ jobs:
         shell: bash
         run: |
           # we obviously don't want to do this here, just want to see if it builds
-          curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "C:\ProgramData\Docker\cli-plugins\docker-buildx.exe"
+          printenv
+          mkdir -p "$USERPROFILE\.docker\cli-plugins"
+          curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "$USERPROFILE\.docker\cli-plugins\docker-buildx.exe"
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
           make bake TAGS=3.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,13 @@ jobs:
         # TODO: keep an eye when macos-14+ (M1) docker support is available
         os: [windows-latest, ubuntu-latest]
     steps:
-      - name: Set up Docker Buildx
-        if: matrix.os == 'windows-latest'
-        uses: docker/setup-buildx-action@v2
       - name: make build
         if: matrix.os == 'windows-latest'
         shell: bash
         run: |
           # we obviously don't want to do this here, just want to see if it builds
+          curl "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o C:\ProgramData\Docker\cli-plugins\docker-buildx
+          docker buildx install
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
           make bake TAGS=3.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,10 @@ jobs:
         run: |
           # we obviously don't want to do this here, just want to see if it builds
           printenv
-          mkdir -p "$USERPROFILE\.docker\cli-plugins"
-          curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "$USERPROFILE\.docker\cli-plugins\docker-buildx.exe"
+          mkdir -p "/c/Users/runneradmin/.docker/cli-plugins"
+          export PATH="$PATH:/c/Users/runneradmin/.docker/cli-plugins"
+          curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "/c/Users/runneradmin/.docker/cli-plugins/docker-buildx.exe"
+          ls -l /c/Users/runneradmin/.docker/cli-plugins
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk
           cd /tmp/ibk
           make bake TAGS=3.2.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,8 @@ jobs:
           # we obviously don't want to do this here, just want to see if it builds
           mkdir -p "/c/Users/runneradmin/.docker/cli-plugins"
           export PATH="$PATH:/c/Users/runneradmin/.docker/cli-plugins"
-          curl -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "/c/Users/runneradmin/.docker/cli-plugins/docker-buildx.exe"
+          curl -L -s "https://github.com/docker/buildx/releases/download/v0.14.0/buildx-v0.14.0.windows-amd64.exe" -o "/c/Users/runneradmin/.docker/cli-plugins/docker-buildx.exe"
+
           ls -l /c/Users/runneradmin/.docker/cli-plugins
           docker system info
           git clone https://github.com/Islandora-Devops/isle-buildkit /tmp/ibk


### PR DESCRIPTION
Lets see if we can add Windows test support here.

## Note on MacOS tests

Until [M1 runners have docker support](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md) getting mac os tests to run on modern hardware is not possible. And adding docker support to a `macos-13` runner and getting isle-dc running takes over 30min so not feasible to test.

But lets