### PR TITLE
Fixup for waiting for islandora.traefik.me loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -687,7 +687,7 @@ compose-up:
 .PHONY: wait-for-drupal-locally
 .SILENT: wait-for-drupal-locally
 wait-for-drupal-locally:
-	while ! curl -s -o /dev/null -m 5 https://islandora.traefik.me/ ; do \
-		echo "Waiting for https://islandora.traefik.me to be available..."; \
+	while ! curl -s -o /dev/null -m 5 https://$(DOMAIN)/ ; do \
+		echo "Waiting for https://$(DOMAIN) to be available..."; \
 		sleep 1; \
 	done


### PR DESCRIPTION
The wait-for-drupal-locally Makefile target gets stuck in an infinite loop if you have modified the DOMAIN environment setting from the default islandora.traefik.me.

This pull request fixes that issue and uses the DOMAIN setting from the user .env file.