### PR TITLE
Set starter-site to main

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:1.7.1
+CODEBASE_PACKAGE=islandora/islandora-starter-site:main
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.

--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:1.6.2
+CODEBASE_PACKAGE=islandora/islandora-starter-site:1.7.1
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.

--- a/sample.env
+++ b/sample.env
@@ -49,7 +49,7 @@ CUSTOM_IMAGE_TAG=latest
 
 # Packagist repo to use when creating a site with make starter
 # Change this if you want to build from a different codebase than the starter site
-CODEBASE_PACKAGE=islandora/islandora-starter-site:main
+CODEBASE_PACKAGE=islandora/islandora-starter-site:dev-main
 
 # Includes `traefik` as a service, if false assume we are sharing a traefik
 # from another project.


### PR DESCRIPTION
Since the islandora-starter-site version is only ever used when running `make starter`, set the package to `main` so new installs are always kept up to date