### PR TITLE
Use 'main' for buildkit image tag.

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -94,7 +94,7 @@ REPOSITORY=islandora
 
 # The version of the isle-buildkit images, non isle-buildkit images have
 # their versions specified explicitly in their respective docker-compose files.
-TAG=3.2.2
+TAG=main
 
 ###############################################################################
 # Exposed Containers & Ports


### PR DESCRIPTION
## What does this pull request do?

Resolves #397  . Now BuildKit versions don't require a manual update to ISLE-DC's developpment branch to get latest images.

## How should this be tested

1. Run ```make starter_dev``` from a clean instance of ISLE-DC.
2. Observe that the images that get pulled are the newest ones from https://github.com/Islandora-Devops/isle-buildkit/tags

