### PR TITLE
Run composer as nginx user to avoid permissions conflict.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,9 @@ starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) bash -c 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
 	else \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) bash -c 'cd /home/root && composer install'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root && composer install'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) compose-up

--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,9 @@ starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) -u nginx bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase; mv /tmp/codebase/* /home/root;'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root -u nginx $(REPOSITORY)/nginx:$(TAG) bash -c 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
 	else \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) -u nginx bash -lc 'cd /home/root; composer install'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root -u nginx $(REPOSITORY)/nginx:$(TAG) bash -c 'cd /home/root && composer install'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) compose-up
@@ -173,14 +173,14 @@ starter_dev: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	$(MAKE) compose-up
-	docker compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ ; su nginx -s /bin/bash -c "composer install"'
+	docker compose exec -T -u nginx drupal sh -c 'composer install && chown -R nginx:nginx .'
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 
 .PHONY: production
 production: init
 	$(MAKE) compose-up
-	docker compose exec -u nginx -T drupal -lc 'composer install; chown -R nginx:nginx .'
+	docker compose exec -T -u nginx drupal sh -c 'composer install && chown -R nginx:nginx .'
 	$(MAKE) starter-finalize ENVIRONMENT=starter
 
 

--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,6 @@ local:
 ## Make a local site with codebase directory bind mounted, using starter site unless other package specified in .env or present already.
 starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
-	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
 		docker container run --rm -v $(CURDIR)/codebase:/home/root -u nginx $(REPOSITORY)/nginx:$(TAG) bash -c 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
@@ -174,7 +173,7 @@ starter_dev: generate-secrets
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
 	$(MAKE) compose-up
-	docker compose exec -T -u nginx drupal sh -c 'composer install && chown -R nginx:nginx .'
+	docker compose exec -T -u nginx drupal sh -c 'composer install'
 	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
 
 

--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,9 @@ starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase; mv /tmp/codebase/* /home/root;'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) -u nginx bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase; mv /tmp/codebase/* /home/root;'; \
 	else \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root; composer install'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) -u nginx bash -lc 'cd /home/root; composer install'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) compose-up
@@ -180,7 +180,7 @@ starter_dev: generate-secrets
 .PHONY: production
 production: init
 	$(MAKE) compose-up
-	docker compose exec -T drupal with-contenv bash -lc 'composer install; chown -R nginx:nginx .'
+	docker compose exec -u nginx -T drupal -lc 'composer install; chown -R nginx:nginx .'
 	$(MAKE) starter-finalize ENVIRONMENT=starter
 
 

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ local:
 ## Make a local site with codebase directory bind mounted, using starter site unless other package specified in .env or present already.
 starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
+	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
 		docker container run --rm -v $(CURDIR)/codebase:/home/root -u nginx $(REPOSITORY)/nginx:$(TAG) bash -c 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \

--- a/Makefile
+++ b/Makefile
@@ -154,9 +154,9 @@ starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
 	$(MAKE) starter-init ENVIRONMENT=starter
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root -u nginx $(REPOSITORY)/nginx:$(TAG) bash -c 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) bash -c 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
 	else \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root -u nginx $(REPOSITORY)/nginx:$(TAG) bash -c 'cd /home/root && composer install'; \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) bash -c 'cd /home/root && composer install'; \
 	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) compose-up


### PR DESCRIPTION
Addressing issues in https://github.com/Islandora-Devops/isle-dc/issues/306

This runs the 3 compose commands in the Makefile as the nginx user. By doing so the installed modules have the correct permissions and the settings.php file have its owner permissions changed.

After running `make starter_dev` this is a report of the settings file
```
File Information for: web/sites/default/settings.php
------------------------
File Type: regular file
Permissions: -r--r--r-- (Numeric: 444)
Owner: nginx
Group: nginx
Owner Permissions: 4 (4=read, 2=write, 1=execute)
Group Permissions: 4 (4=read, 2=write, 1=execute)
Other Permissions: 4 (4=read, 2=write, 1=execute)
Is Executable: Yes
Is marked as 'Archive': No
------------------------
Modified: 2024-07-25 13:42:40.254382786 +0000
Last Accessed: 2024-07-25 13:42:41.479146012 +0000
```

## To test (from a clean repo)
1. Run `make start_dev` on flesh isle-dc (without codebase)
2. Once complete check who owns the /var/www/drupal/vendor directory(likely root)
3. Check that the /var/www/drupal/web/sites/default/settings.php is set to archive (read only)
4. Run `make clean`
5. Run `make start_dev` on flesh isle-dc (without codebase) again
6. Once complete check who owns the /var/www/drupal/vendor directory(likely **nginx**)
7. Check that the /var/www/drupal/web/sites/default/settings.php is set to archive (`-r--r--r--` but no archive flag)


