### PR TITLE
Update how settings.php gets appended

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -558,7 +558,7 @@ delete-shortcut-entities:
 .PHONY: hydrate
 .SILENT: hydrate
 ## Reconstitute the site from environment variables.
-hydrate: update-settings-php update-config-from-environment solr-cores namespaces run-islandora-migrations
+hydrate: update-config-from-environment solr-cores namespaces run-islandora-migrations
 	docker compose exec -T drupal drush cr -y
 
 

--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ starter: generate-secrets
 	cp default_settings.txt ./codebase/assets/patches
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
 	$(MAKE) compose-up
+	docker compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ ; su nginx -s /bin/bash -c "composer install"'
 	$(MAKE) starter-finalize ENVIRONMENT=starter
 
 
@@ -583,6 +584,7 @@ starter-init: init
 starter-finalize:
 	docker compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx . ; echo "Chown Complete"'
 	$(MAKE) drupal-database
+
 	docker compose exec -T drupal with-contenv bash -lc "drush si -y --existing-config minimal --account-pass '$(shell cat secrets/live/DRUPAL_DEFAULT_ACCOUNT_PASSWORD)'"
 	docker compose exec -T drupal with-contenv bash -lc "drush cr"
 	docker compose exec -T drupal with-contenv bash -lc "drush -l $(SITE) user:role:add fedoraadmin admin"

--- a/build/docker-compose/docker-compose.drupal.yml
+++ b/build/docker-compose/docker-compose.drupal.yml
@@ -9,10 +9,12 @@ services:
   drupal:
     restart: ${RESTART_POLICY:-unless-stopped}
     environment:
+      DRUPAL_DEFAULT_BROKER_URL: tcp://activemq:61613
       DRUPAL_DEFAULT_CANTALOUPE_URL: https://${DOMAIN}/cantaloupe/iiif/2
       DRUPAL_DEFAULT_FCREPO_HOST: ${DOMAIN}
       DRUPAL_DEFAULT_FCREPO_PORT: 8081
-      DRUPAL_DEFAULT_SITE_URL: http://${DOMAIN} # Make sure this is just http and not https!
+      DRUPAL_DEFAULT_FCREPO_URL: ${DOMAIN}
+      DRUPAL_DEFAULT_SITE_URL: ${DOMAIN}
       DRUPAL_DEFAULT_PROFILE: ${DRUPAL_INSTALL_PROFILE}
       PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}
       PHP_POST_MAX_SIZE: ${PHP_POST_MAX_SIZE}

--- a/build/docker-compose/docker-compose.drupal.yml
+++ b/build/docker-compose/docker-compose.drupal.yml
@@ -1,5 +1,4 @@
 # These are the common settings for any drupal when used with any of the environment types.
-version: "3.7"
 networks:
   default:
     internal: true
@@ -11,9 +10,7 @@ services:
     environment:
       DRUPAL_DEFAULT_BROKER_URL: tcp://activemq:61613
       DRUPAL_DEFAULT_CANTALOUPE_URL: https://${DOMAIN}/cantaloupe/iiif/2
-      DRUPAL_DEFAULT_FCREPO_HOST: ${DOMAIN}
-      DRUPAL_DEFAULT_FCREPO_PORT: 8081
-      DRUPAL_DEFAULT_FCREPO_URL: ${DOMAIN}
+      DRUPAL_DEFAULT_FCREPO_URL: http://${DOMAIN}:8081/fcrepo/rest/
       DRUPAL_DEFAULT_SITE_URL: ${DOMAIN}
       DRUPAL_DEFAULT_PROFILE: ${DRUPAL_INSTALL_PROFILE}
       PHP_MEMORY_LIMIT: ${PHP_MEMORY_LIMIT}

--- a/default_settings.txt
+++ b/default_settings.txt
@@ -1,0 +1,83 @@
+/**
+ *  Section appended onto drupal/core default.settings.php via "drupal-scaffold" in composer.json.
+ */
+
+// Let Drush use all the memory available.
+if (PHP_SAPI === 'cli') {
+  ini_set('memory_limit', '-1');
+}
+
+// Required when running Drupal behind a reverse proxy.
+$settings['reverse_proxy'] = TRUE;
+$settings['reverse_proxy_addresses'] = array($_SERVER['REMOTE_ADDR']);
+$settings['reverse_proxy_trusted_headers'] = \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_FOR | 
+\Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_PROTO | \Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_PORT;
+
+/**
+ * Private file path:
+ *
+ * A local file system path where private files will be stored. This directory
+ * must be absolute, outside of the Drupal installation directory and not
+ * accessible over the web.
+ *
+ * Note: Caches need to be cleared when this value is changed to make the
+ * private:// stream wrapper available to the system.
+ *
+ * See https://www.drupal.org/documentation/modules/file for more information
+ * about securing private files.
+ */
+$settings['file_private_path'] = '/var/www/drupal/private/';
+
+// Shared configuration, config_split is used for any site specific differences.
+$settings['config_sync_directory'] = '/var/www/drupal/config/sync';
+
+// Content sync module.
+global $content_directories;
+$content_directories['sync'] = '/var/www/drupal/content/sync';
+
+// Container environment variable path.
+$path = "/var/run/s6/container_environment/";
+
+// Some configurations are derived from environment variables.
+$config['islandora.settings']['broker_url'] = file_get_contents($path . 'DRUPAL_DEFAULT_BROKER_URL');
+$config['islandora.settings']['broker_user'] = file_exists($path . 'DRUPAL_DEFAULT_BROKER_USER') ? file_get_contents($path . 'DRUPAL_DEFAULT_BROKER_USER') : NULL;
+$config['islandora.settings']['broker_password'] = file_exists($path . 'DRUPAL_DEFAULT_BROKER_PASSWORD') ? file_get_contents($path . 'DRUPAL_DEFAULT_BROKER_PASSWORD') : NULL;
+$config['islandora_iiif.settings']['iiif_server'] = file_get_contents($path . 'DRUPAL_DEFAULT_CANTALOUPE_URL');
+$config['openseadragon.settings']['iiif_server'] = file_get_contents($path . 'DRUPAL_DEFAULT_CANTALOUPE_URL');
+$config['search_api.server.default_solr_server']['backend_config']['connector_config']['host'] = file_get_contents($path . 'DRUPAL_DEFAULT_SOLR_HOST');
+$config['search_api.server.default_solr_server']['backend_config']['connector_config']['port'] = file_get_contents($path . 'DRUPAL_DEFAULT_SOLR_PORT');
+$config['search_api.server.default_solr_server']['backend_config']['connector_config']['core'] = file_get_contents($path . 'DRUPAL_DEFAULT_SOLR_CORE');
+
+// Others are hardcoded.
+$config['key.key.islandora_rsa_key']['key_provider_settings']['file_location'] = '/opt/keys/jwt/private.key';
+
+// Some settings are derived from environment variables.
+$settings['hash_salt'] = file_get_contents($path . 'DRUPAL_DEFAULT_SALT');
+$settings['trusted_host_patterns'] = [
+  0 => file_get_contents($path . 'DRUPAL_DEFAULT_SITE_URL'),
+];
+
+// Database settings are also derived from environment variables.
+$databases['default']['default'] = [
+  'database' => file_get_contents($path . 'DRUPAL_DEFAULT_DB_NAME'),
+  'username' => file_get_contents($path . 'DRUPAL_DEFAULT_DB_USER'),
+  'password' => file_get_contents($path . 'DRUPAL_DEFAULT_DB_PASSWORD'),
+  'host' => file_get_contents($path . 'DB_MYSQL_HOST'),
+  'port' => file_get_contents($path . 'DB_MYSQL_PORT'),
+  'prefix' => '',
+  'driver' => 'mysql',
+  'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
+];
+
+// Flysystem
+$settings['flysystem']['fedora']['driver'] = 'fedora';
+$settings['flysystem']['fedora']['config']['root'] = file_get_contents($path . 'DRUPAL_DEFAULT_FCREPO_URL');
+
+// Change the php_storage settings in your setting.php. It is recommend that
+// this directory be outside out of the docroot.
+$settings['php_storage']['twig']['directory'] = $settings['file_private_path'] . '/php';
+$settings['php_storage']['twig']['secret'] = $settings['hash_salt'];
+
+/**
+ *  End Section.
+ */


### PR DESCRIPTION
For issue https://github.com/Islandora-Devops/isle-dc/issues/401

This removes the update-settings make command from the starter variants and replaces the default_settings.txt in the starter site. This is how the isle site template does it's configuration.

To test run make starter_dev or make starter.