### PR TITLE
Remove docker compose version in the yaml files.

### DIFF
--- a/build/docker-compose/docker-compose.acme.yml
+++ b/build/docker-compose/docker-compose.acme.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   traefik:
     # Do not set `api.insecure`, `api.dashboard`, `api.debug` to `true` in production.

--- a/build/docker-compose/docker-compose.activemq.yml
+++ b/build/docker-compose/docker-compose.activemq.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.alpaca.yml
+++ b/build/docker-compose/docker-compose.alpaca.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.blazegraph.yml
+++ b/build/docker-compose/docker-compose.blazegraph.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.cantaloupe.yml
+++ b/build/docker-compose/docker-compose.cantaloupe.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.code-server.yml
+++ b/build/docker-compose/docker-compose.code-server.yml
@@ -2,7 +2,6 @@
 # 
 # References:
 # - https://www.drupal.org/docs
-version: '3.7'
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.crayfish.yml
+++ b/build/docker-compose/docker-compose.crayfish.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.crayfits.yml
+++ b/build/docker-compose/docker-compose.crayfits.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.custom.yml
+++ b/build/docker-compose/docker-compose.custom.yml
@@ -1,5 +1,4 @@
 # This file builds a local image from the codebase folder
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.demo.yml
+++ b/build/docker-compose/docker-compose.demo.yml
@@ -5,7 +5,6 @@
 #
 # Organizations should not use this as their base instead they should refer
 # to the documentation in this project for the correct approach.
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.drupal.mariadb.yml
+++ b/build/docker-compose/docker-compose.drupal.mariadb.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   # Override defaults so Mariadb is used as the database for this service.
   drupal:

--- a/build/docker-compose/docker-compose.drupal.postgresql.yml
+++ b/build/docker-compose/docker-compose.drupal.postgresql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   # Override defaults so PostgreSQL is used as the database for this service.
   drupal:

--- a/build/docker-compose/docker-compose.drupal.yml
+++ b/build/docker-compose/docker-compose.drupal.yml
@@ -1,5 +1,4 @@
 # These are the common settings for any drupal when used with any of the environment types.
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.etcd.yml
+++ b/build/docker-compose/docker-compose.etcd.yml
@@ -1,6 +1,5 @@
 # Example of using a different backend for confd rather then
 # environment variables.
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.fcrepo.mariadb.yml
+++ b/build/docker-compose/docker-compose.fcrepo.mariadb.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   # Override defaults so Mariadb is used as the database for this service.
   fcrepo:

--- a/build/docker-compose/docker-compose.fcrepo.postgresql.yml
+++ b/build/docker-compose/docker-compose.fcrepo.postgresql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   # Override defaults so PostgreSQL is used as the database for this service.
   fcrepo:

--- a/build/docker-compose/docker-compose.fcrepo.yml
+++ b/build/docker-compose/docker-compose.fcrepo.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.fcrepo6.mariadb.yml
+++ b/build/docker-compose/docker-compose.fcrepo6.mariadb.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   # Override defaults so Mariadb is used as the database for this service.
   fcrepo:

--- a/build/docker-compose/docker-compose.fcrepo6.postgresql.yml
+++ b/build/docker-compose/docker-compose.fcrepo6.postgresql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   # Override defaults so PostgreSQL is used as the database for this service.
   fcrepo:

--- a/build/docker-compose/docker-compose.fcrepo6.yml
+++ b/build/docker-compose/docker-compose.fcrepo6.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.local.yml
+++ b/build/docker-compose/docker-compose.local.yml
@@ -4,7 +4,6 @@
 # - composer requires / install
 # - Drush commands
 # - Manual changes to the codebase directory
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.mariadb.yml
+++ b/build/docker-compose/docker-compose.mariadb.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.postgresql.yml
+++ b/build/docker-compose/docker-compose.postgresql.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.secrets.yml
+++ b/build/docker-compose/docker-compose.secrets.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 secrets:
   ACTIVEMQ_PASSWORD:
     file: "../../secrets/live/ACTIVEMQ_PASSWORD"

--- a/build/docker-compose/docker-compose.solr.yml
+++ b/build/docker-compose/docker-compose.solr.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.starter.yml
+++ b/build/docker-compose/docker-compose.starter.yml
@@ -4,7 +4,6 @@
 # - composer requires / install
 # - Drush commands
 # - Manual changes to the codebase directory
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.starter_dev.yml
+++ b/build/docker-compose/docker-compose.starter_dev.yml
@@ -4,7 +4,6 @@
 # - composer requires / install
 # - Drush commands
 # - Manual changes to the codebase directory
-version: "3.7"
 networks:
   default:
     internal: true

--- a/build/docker-compose/docker-compose.traefik.yml
+++ b/build/docker-compose/docker-compose.traefik.yml
@@ -7,7 +7,6 @@
 # For a traefik to be able to route traffic to a given container, that
 # container needs to be on the `gateway` network, otherwise traefik will
 # discover it via Docker but will not be able to redirect traffic to it.
-version: "3.7"
 networks:
   gateway:
     driver: bridge

--- a/build/docker-compose/docker-compose.watchtower.yml
+++ b/build/docker-compose/docker-compose.watchtower.yml
@@ -1,7 +1,6 @@
 # This service will automatically restart a service if a newer image is
 # available on the system, useful for local development but should not
 # be used in production.
-version: "3.7"
 services:
   watchtower:
     image: containrrr/watchtower


### PR DESCRIPTION
Including the version number in the docker compose yaml files throws a docker compose version is obsolete message when running make starter/starter_dev. Docker compose v2 will always use the latest version of the compose file scheme and it no longer requires the version number.

To test, run make starter or starter_dev and observe that there is no longer the version obsolete message.