### PR TITLE
Add missing etcd-data volume 

### DIFF
--- a/build/docker-compose/docker-compose.etcd.yml
+++ b/build/docker-compose/docker-compose.etcd.yml
@@ -3,6 +3,8 @@
 networks:
   default:
     internal: true
+volumes:
+  etcd-data:
 services:
   # Single node cluster.
   #


### PR DESCRIPTION
`etcd-data volume` missing from etcd service - will not `make` without :

`INCLUDE_ETCD_SERVICE=true`

set in `.env`