### PR TITLE
Update patch_views.sh

### DIFF
--- a/scripts/patch_views.sh
+++ b/scripts/patch_views.sh
@@ -1,55 +1,64 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 # To be precise on the error message that matches the error this should address.
 ERROR_MESSAGE=$(drush watchdog:show --severity=Error --filter="InvalidArgumentException: A valid cache entry key is required" | awk '{print $6}')
 
-# If error message equals to "No such file or directory", then exit.
+# If error message equals to "InvalidArgumentException", then exit.
 if [[ $ERROR_MESSAGE == *'InvalidArgumentException'* ]]; then
 
-	# Install Drupal Console.
-	drupal_console_installed() {
-		composer show 'drupal/console' | grep -q '/var/www/drupal/vendor/drupal/console'
-	}
-	if drupal_console_installed; then
-		echo 'Package installed'
-	else
-		composer require drupal/console:~1.0 --prefer-dist --optimize-autoloader -W
-	fi
+    Check if drush is installed (Drupal Console replacement).
+    drush_installed() {
+        composer show 'drush/drush' | grep -q '/var/www/drupal/vendor/drush/drush'
+    }
+    if drush_installed; then
+        echo 'Drush installed'
+    else
+        composer require drush/drush
+    fi
 
-	# Reinstall views
-	enabled_view=`/var/www/drupal/vendor/drupal/console/bin/drupal debug:views --status='Enabled' | cut -d ' ' -f 2 | tail -n +2`
-	for dis_view in $enabled_view; do
-		echo "Disabling view $dis_view"
-		/var/www/drupal/vendor/drupal/console/bin/drupal views:disable $dis_view
-	done
+    # Retrieve the list of enabled views by isolating the first column (view names) where the status is "Enabled"
+    VIEWS_FILE="enabled_views.txt"
 
-	for en_view in $enabled_view; do
-		echo "Reenabling view $en_view"
-		/var/www/drupal/vendor/drupal/console/bin/drupal views:enable $en_view
-	done
+    # Get the list of enabled views and store it in the file without truncation
+    # Force drush to output in CSV format to avoid terminal width truncation issues
+    drush views:list --status=enabled --format=csv | grep -v "Machine name" | awk -F',' '{print $1}' > "$VIEWS_FILE"
 
-	# Install devel.
-	devel_installed() {
-		composer show 'drupal/devel' | grep -q '/var/www/drupal/web/modules/contrib/devel'
-	}
-	if devel_installed; then
-		echo 'Package installed'
-	else
-		composer require 'drupal/devel:^4.1' -W
-	fi
-	drush pm:enable -y devel
+    # Check if the file exists and is not empty
+    if [[ ! -s "$VIEWS_FILE" ]]; then
+        printf "Error: No enabled views found or unable to retrieve views list.\n" >&2
+        exit 1
+    fi
 
-	echo -e "\n\nThis will likely throw an error, but that's okay.  It's just a patch.\n\n"
-	{ # try
-    drush dev:reinstall -y islandora
-	} || { # catch
-		echo -e "\nIgnore these errors. This will fail if any content is already created.\n\n"
-	}
+    # Read the file line by line to process each view
+    while IFS= read -r dis_view; do
+        printf "Reloading view: %s\n" "$dis_view"
+        drush views:disable "$dis_view"
+        sleep 1
+        drush views:enable "$dis_view"
+    done < "$VIEWS_FILE"
 
-	# Clear caches
-	/var/www/drupal/vendor/drupal/console/bin/drupal cache:rebuild
-	/var/www/drupal/vendor/drupal/console/bin/drupal cr all
-	/var/www/drupal/vendor/drupal/console/bin/drupal node:access:rebuild
-	drush cron
-fi
+    # Install devel.
+    devel_installed() {
+        composer show 'drupal/devel' | grep -q '/var/www/drupal/web/modules/contrib/devel'
+    }
+    if devel_installed; then
+        echo 'Devel module installed'
+    else
+        composer require 'drupal/devel' -W
+    fi
+    drush pm:enable -y devel
+
+    echo -e "nnThis will likely throw an error, but that's okay.  It's just a patch.nn"
+    { # try
+        drush pm:uninstall -y islandora
+    } || { # catch
+        echo -e "nIgnore these errors. This will fail if any content is already created.nn"
+    }
+
+    # Clear caches
+    drush cache:rebuild
+    drush cr
+    drush node-access-rebuild
+    drush cron
+# fi

--- a/scripts/patch_views.sh
+++ b/scripts/patch_views.sh
@@ -59,6 +59,5 @@ if [[ $ERROR_MESSAGE == *'InvalidArgumentException'* ]]; then
     # Clear caches
     drush cache:rebuild
     drush cr
-    drush node-access-rebuild
     drush cron
 # fi

--- a/scripts/patch_views.sh
+++ b/scripts/patch_views.sh
@@ -7,7 +7,7 @@ ERROR_MESSAGE=$(drush watchdog:show --severity=Error --filter="InvalidArgumentEx
 # If error message equals to "InvalidArgumentException", then exit.
 if [[ $ERROR_MESSAGE == *'InvalidArgumentException'* ]]; then
 
-    Check if drush is installed (Drupal Console replacement).
+    # Check if drush is installed (Drupal Console replacement).
     drush_installed() {
         composer show 'drush/drush' | grep -q '/var/www/drupal/vendor/drush/drush'
     }

--- a/scripts/patch_views.sh
+++ b/scripts/patch_views.sh
@@ -45,12 +45,12 @@ troubleshoot_drupal() {
     echo "---------------------"
 
     # Always process views, regardless of error message
-    # while IFS= read -r dis_view; do
-    #     log "Processing view: $dis_view"
-    #     drush views:disable "$dis_view" || log "Error disabling view: $dis_view"
-    #     sleep 1
-    #     drush views:enable "$dis_view" || log "Error enabling view: $dis_view"
-    # done < "$VIEWS_FILE"
+    while IFS= read -r dis_view; do
+         log "Processing view: $dis_view"
+         drush views:disable "$dis_view" || log "Error disabling view: $dis_view"
+         sleep 1
+         drush views:enable "$dis_view" || log "Error enabling view: $dis_view"
+    done < "$VIEWS_FILE"
 
     # Ensure Devel module
     DEVEL_INITIALLY_ENABLED=$(drush pm:list | grep devel | grep -F 'Devel (devel)' | grep -q "Enabled" && echo "Enabled" || echo "Disabled")
@@ -66,9 +66,9 @@ troubleshoot_drupal() {
         drush pm:enable -y devel || log "Error: Devel module enabling failed"
     fi
 
-    # Attempt to reinstall Islandora (with error suppression)
-    log "Attempting Islandora module uninstallation..."
-    drush devel:reinstall -y islandora || log "Islandora uninstall may have partial failure. This can be ignored."
+    # Attempt to reinstall Islandora (with error suppression). For new installs only.
+    # log "Attempting Islandora module uninstallation..."
+    # drush devel:reinstall -y islandora || log "Islandora uninstall may have partial failure. This can be ignored."
 
     # Clear caches
     log "Rebuilding caches..."

--- a/scripts/patch_views.sh
+++ b/scripts/patch_views.sh
@@ -1,63 +1,101 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-# To be precise on the error message that matches the error this should address.
-ERROR_MESSAGE=$(drush watchdog:show --severity=Error --filter="InvalidArgumentException: A valid cache entry key is required" | awk '{print $6}')
+# Log file for tracking script operations
+LOG_FILE="/tmp/drupal_troubleshoot_$(date +%Y%m%d_%H%M%S).log"
 
-# If error message equals to "InvalidArgumentException", then exit.
-if [[ $ERROR_MESSAGE == *'InvalidArgumentException'* ]]; then
+# Function to log messages
+log() {
+    echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
 
-    # Check if drush is installed (Drupal Console replacement).
-    drush_installed() {
-        composer show 'drush/drush' | grep -q '/var/www/drupal/vendor/drush/drush'
-    }
-    if drush_installed; then
-        echo 'Drush installed'
-    else
+# Verify required commands exist
+check_dependencies() {
+    local deps=("drush" "composer" "awk" "grep")
+    for cmd in "${deps[@]}"; do
+        if ! command -v "$cmd" &> /dev/null; then
+            log "Error: $cmd is not installed"
+            exit 1
+        fi
+    done
+}
+
+# Check Drush installation
+ensure_drush() {
+    if ! composer show 'drush/drush' &>/dev/null; then
+        log "Installing Drush..."
         composer require drush/drush
+    else
+        log "Drush is already installed"
     fi
+}
 
-    # Retrieve the list of enabled views by isolating the first column (view names) where the status is "Enabled"
-    VIEWS_FILE="enabled_views.txt"
+# Main troubleshooting function
+troubleshoot_drupal() {
+    local ERROR_MESSAGE
+    ERROR_MESSAGE=$(drush watchdog:show --severity=Error --filter="InvalidArgumentException: A valid cache entry key is required" | awk '{print $6}')
+    log "Detected Error Message: '$ERROR_MESSAGE'"
 
-    # Get the list of enabled views and store it in the file without truncation
-    # Force drush to output in CSV format to avoid terminal width truncation issues
+    # Retrieve enabled views
+    local VIEWS_FILE="/tmp/enabled_views.txt"
     drush views:list --status=enabled --format=csv | grep -v "Machine name" | awk -F',' '{print $1}' > "$VIEWS_FILE"
 
-    # Check if the file exists and is not empty
-    if [[ ! -s "$VIEWS_FILE" ]]; then
-        printf "Error: No enabled views found or unable to retrieve views list.\n" >&2
-        exit 1
+    log "Views file contents:"
+    log "$VIEWS_FILE"
+    echo "---------------------"
+
+    # Always process views, regardless of error message
+    # while IFS= read -r dis_view; do
+    #     log "Processing view: $dis_view"
+    #     drush views:disable "$dis_view" || log "Error disabling view: $dis_view"
+    #     sleep 1
+    #     drush views:enable "$dis_view" || log "Error enabling view: $dis_view"
+    # done < "$VIEWS_FILE"
+
+    # Ensure Devel module
+    DEVEL_INITIALLY_ENABLED=$(drush pm:list | grep devel | grep -F 'Devel (devel)' | grep -q "Enabled" && echo "Enabled" || echo "Disabled")
+    log "Devel module initial state: $DEVEL_INITIALLY_ENABLED"
+
+    if ! composer show 'drupal/devel' &>/dev/null; then
+        log "Installing Devel module..."
+        composer require 'drupal/devel' -W || log "Error: Devel module installation failed"
     fi
 
-    # Read the file line by line to process each view
-    while IFS= read -r dis_view; do
-        printf "Reloading view: %s\n" "$dis_view"
-        drush views:disable "$dis_view"
-        sleep 1
-        drush views:enable "$dis_view"
-    done < "$VIEWS_FILE"
-
-    # Install devel.
-    devel_installed() {
-        composer show 'drupal/devel' | grep -q '/var/www/drupal/web/modules/contrib/devel'
-    }
-    if devel_installed; then
-        echo 'Devel module installed'
-    else
-        composer require 'drupal/devel' -W
+    # If it wasn't initially enabled, enable it.
+    if [[ "$DEVEL_INITIALLY_ENABLED" == "Disabled" ]]; then
+        drush pm:enable -y devel || log "Error: Devel module enabling failed"
     fi
-    drush pm:enable -y devel
 
-    echo -e "nnThis will likely throw an error, but that's okay.  It's just a patch.nn"
-    { # try
-        drush pm:uninstall -y islandora
-    } || { # catch
-        echo -e "nIgnore these errors. This will fail if any content is already created.nn"
-    }
+    # Attempt to reinstall Islandora (with error suppression)
+    log "Attempting Islandora module uninstallation..."
+    drush devel:reinstall -y islandora || log "Islandora uninstall may have partial failure. This can be ignored."
 
     # Clear caches
+    log "Rebuilding caches..."
     drush cache:rebuild
-    drush cr
     drush cron
-# fi
+
+    log "Troubleshooting complete."
+}
+
+# Main script execution
+main() {
+    check_dependencies
+    ensure_drush
+    troubleshoot_drupal
+}
+
+# Execute main function with error trapping
+if main; then
+    log "Script completed successfully"
+else
+    log "Script encountered errors"
+    exit 1
+fi
+
+# If it wasn't initially enabled, disable it at the end
+if [[ "$DEVEL_INITIALLY_ENABLED" == "Disabled" ]]; then
+    drush pm:uninstall -y devel
+fi
+
+echo "Check LOG at $LOG_FILE"


### PR DESCRIPTION
Drupal console is no longer being maintained and the latest version of isle-dc doesn't include it. It turns out it's pretty difficult to even install it at this point. 

**This PR is to:**
1. update this script to use drush
2. Add some debug visibility incase something goes wrong by outputting the enabled views list to a text file.
3. Works on 1 view at a time (instead of disabling everything and then re-enabling the ones from the list)

### To test:
Run the make command.
```shell
make fix_views
```

### Output:
```shell
Successfully copied 4.1kB to isle-dc-drupal-1:/var/www/drupal/patch_views.sh
Reloading view: advanced_search
 [success] advanced_search disabled.
 [success] advanced_search enabled.
Reloading view: all_taxonomy_terms
 [success] all_taxonomy_terms disabled.
 [success] all_taxonomy_terms enabled.
...
```

This should only select the enabled views, output the list to a file (/var/www/enabled_views.txt), and for each enabled view  disable, then enable the view. Hopefully correcting any broken references within the view. Then it should run a few drush commands to clean up and rebuild cache/menus. This part was already part of the script. 

This script could use some improvements but to keep the scope of this PR focussed it's mainly to replace drupal console with drush. 