### PR TITLE
Fix make starter_dev and run it in the nightly test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
           ./build/scripts/check-secrets.sh yes
         shell: bash
 
-      - name: make starter
-        run: make starter
+      - name: make starter_dev
+        run: make starter_dev
         shell: bash
 
       - name: check online

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: check online
         run: ./scripts/ci/ping.sh
 
-      - run: make down && rm -rf codebase
+      - run: make down && sudo rm -rf codebase
 
       - run: make starter_dev
       - name: check online

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test
 on:
   push:
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
   schedule:
     # UTC
-    - cron: '15 12 * * *'
+    - cron: "15 12 * * *"
 env:
   TERM: xterm-256color
 jobs:
@@ -31,10 +31,13 @@ jobs:
           ./build/scripts/check-secrets.sh yes
         shell: bash
 
-      - name: make starter_dev
-        run: make starter_dev
-        shell: bash
+      - run: make starter
+      - name: check online
+        run: ./scripts/ci/ping.sh
 
+      - run: make down && rm -rf codebase
+
+      - run: make starter_dev
       - name: check online
         run: ./scripts/ci/ping.sh
 

--- a/Makefile
+++ b/Makefile
@@ -153,15 +153,6 @@ local:
 starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
 	$(MAKE) starter-init ENVIRONMENT=$(ENVIRONMENT)
-	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		if [ "$(ENVIRONMENT)" = "starter_dev" ]; then \
-			docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'git clone -b main https://github.com/Islandora-Devops/islandora-starter-site /home/root;'; \
-		else \
-			docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
-		fi \
-	else \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root && composer install'; \
-	fi
 	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=$(ENVIRONMENT)
 	rm ./codebase/assets/patches/default_settings.txt
 	cp default_settings.txt ./codebase/assets/patches
@@ -571,6 +562,20 @@ init: generate-secrets
 .PHONY: starter-init
 starter-init: init
 	mkdir -p $(CURDIR)/codebase
+ifeq ($(ENVIRONMENT),starter_dev)
+	@if [ -z "$$(ls -A $(CURDIR)/codebase)" ]; then \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'git clone -b main https://github.com/Islandora-Devops/islandora-starter-site /home/root'; \
+	else \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root && composer install'; \
+	fi
+else
+	@if [ -z "$$(ls -A $(CURDIR)/codebase)" ]; then \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
+	else \
+		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root && composer install'; \
+	fi
+endif
+
 
 .PHONY: starter-finalize
 starter-finalize:

--- a/Makefile
+++ b/Makefile
@@ -152,36 +152,28 @@ local:
 ## Make a local site with codebase directory bind mounted, using starter site unless other package specified in .env or present already.
 starter: QUOTED_CURDIR = "$(CURDIR)"
 starter: generate-secrets
-	$(MAKE) starter-init ENVIRONMENT=starter
+	$(MAKE) starter-init ENVIRONMENT=$(ENVIRONMENT)
 	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
+		if [ "$(ENVIRONMENT)" = "starter_dev" ]; then \
+			docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'git clone -b main https://github.com/Islandora-Devops/islandora-starter-site /home/root;'; \
+		else \
+			docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'composer create-project $(CODEBASE_PACKAGE) /tmp/codebase && mv /tmp/codebase/* /home/root'; \
+		fi \
 	else \
 		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'cd /home/root && composer install'; \
 	fi
-	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
+	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=$(ENVIRONMENT)
 	rm ./codebase/assets/patches/default_settings.txt
 	cp default_settings.txt ./codebase/assets/patches
-	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter
+	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=$(ENVIRONMENT)
 	$(MAKE) compose-up
 	docker compose exec -T drupal with-contenv bash -lc 'chown -R nginx:nginx /var/www/drupal/ ; su nginx -s /bin/bash -c "composer install"'
 	$(MAKE) starter-finalize ENVIRONMENT=starter
 
 
 .PHONY: starter_dev
-## Make a local site with codebase directory bind mounted, using cloned starter site.
-starter_dev: QUOTED_CURDIR = "$(CURDIR)"
-starter_dev: generate-secrets
-	$(MAKE) starter-init ENVIRONMENT=starter_dev
-	if [ -z "$$(ls -A $(QUOTED_CURDIR)/codebase)" ]; then \
-		docker container run --rm -v $(CURDIR)/codebase:/home/root $(REPOSITORY)/nginx:$(TAG) with-contenv bash -lc 'git clone -b main https://github.com/Islandora-Devops/islandora-starter-site /home/root;'; \
-	fi
-	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
-	rm ./codebase/assets/patches/default_settings.txt
-	cp default_settings.txt ./codebase/assets/patches
-	$(MAKE) set-files-owner SRC=$(CURDIR)/codebase ENVIRONMENT=starter_dev
-	$(MAKE) compose-up
-	docker compose exec -T -u nginx drupal sh -c 'composer install'
-	$(MAKE) starter-finalize ENVIRONMENT=starter_dev
+starter_dev: ENVIRONMENT=starter_dev
+starter_dev: starter
 
 
 .PHONY: production


### PR DESCRIPTION
`make starter_dev` was throwing a permission error due to the git directory's spurious ownership (as a result of the safety check `git` put in place in response to [CVE-2022-24765](https://github.blog/open-source/git/git-security-vulnerability-announced/#cve-2022-24765))

```
docker compose exec -T -u nginx drupal sh -c 'composer install'
The repository at "/var/www/drupal" does not have the correct ownership and git refuses to use it:
fatal: detected dubious ownership in repository at '/var/www/drupal'
To add an exception for this directory, call:
	git config --global --add safe.directory /var/www/drupal
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Package operations: 179 installs, 0 updates, 0 removals
In Filesystem.php line 261:
  /var/www/drupal/vendor does not exist and could not be created:
install [--prefer-source] [--prefer-dist] [--prefer-install PREFER-INSTALL] [--dry-run] [--download-only] [--dev] [--no-suggest] [--no-dev] [--no-autoloader] [--no-progress] [--no-install] [--audit] [--audit-format AUDIT-FORMAT] [-v|vv|vvv|--verbose] [-o|--optimize-autoloader] [-a|--classmap-authoritative] [--apcu-autoloader] [--apcu-autoloader-prefix APCU-AUTOLOADER-PREFIX] [--ignore-platform-req IGNORE-PLATFORM-REQ] [--ignore-platform-reqs] [--] [<packages>...]
exit status 1
make: *** [Makefile:181: starter_dev] Error 1
```

The fix was to have `make starter_dev` use the same permissions as `make starter` (which had this fix in already)

To test, see without this PR `make starter_dev` fails. With this PR, the same command works. Then just make sure you can make edits to the Drupal site.