### PR TITLE
Backport mkcert install from isle-site-template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,9 +296,7 @@ endif
 download-default-certs: mkcert
 	mkdir -p certs
 	-rm -f certs/cert.pem certs/privkey.pem
-	echo "THE NEXT COMMAND WILL ASK FOR SUDO PWD AND LIKELY MORE..."
-	mkcert -install
-	mkcert -key-file certs/privkey.pem -cert-file certs/cert.pem islandora.dev "*.islandora.dev" localhost 127.0.0.1 ::1
+	./scripts/generate-certs.sh
 
 
 # Run Composer Update in your Drupal container

--- a/scripts/generate-certs.sh
+++ b/scripts/generate-certs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euf -o pipefail
+
+PROGDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd | xargs dirname)"
+readonly PROGDIR
+
+# For some commands we must invoke a Windows executable if in the context of
+# WSL.
+IS_WSL=$(grep -q WSL /proc/version 2>/dev/null && echo "true" || echo "false")
+readonly IS_WSL
+if [[ "${IS_WSL}" == "true" ]]; then
+  MKCERT=mkcert.exe
+else
+  MKCERT=mkcert
+fi
+readonly MKCERT
+
+if [[ "${IS_WSL}" == "true" ]]; then
+  CAROOT=$("${MKCERT}" -CAROOT | xargs -0 wslpath -u)
+else
+  CAROOT=$("${MKCERT}" -CAROOT)
+fi
+readonly CAROOT
+
+"${MKCERT}" -install || true # Ignore errors, as java key stores are sometimes not owned by the user in Windows.
+
+if [ ! -f "${PROGDIR}/certs/rootCA-key.pem" ]; then
+  cp "${CAROOT}/rootCA-key.pem" "${PROGDIR}/certs/rootCA-key.pem"
+fi
+
+if [ ! -f "${PROGDIR}/certs/rootCA.pem" ]; then
+  cp "${CAROOT}/rootCA.pem" "${PROGDIR}/certs/rootCA.pem"
+fi
+
+"${MKCERT}" -cert-file certs/cert.pem -key-file certs/privkey.pem \
+  "*.islandora.dev" \
+  "islandora.dev" \
+  "*.islandora.io" \
+  "islandora.io" \
+  "*.islandora.info" \
+  "islandora.info" \
+  "localhost" \
+  "127.0.0.1" \
+  "::1"
+
+printf '%s' "$(id -u)" > ./certs/UID


### PR DESCRIPTION
isle-site-template provided windows support that was not included when we added mkcert to this repo. Bringing that logic in for better Windows support.

Closes https://github.com/Islandora/documentation/issues/2360