### PR TITLE
Add traefik read timeout conf

### DIFF
--- a/build/docker-compose/docker-compose.traefik.yml
+++ b/build/docker-compose/docker-compose.traefik.yml
@@ -32,6 +32,7 @@ services:
       - --entryPoints.activemq.address=:8161
       - --entryPoints.solr.address=:8983
       - --entryPoints.code-server.address=:8443
+      - --entryPoints.https.transport.respondingTimeouts.readTimeout=${PHP_MAX_EXECUTION_TIME:-60}
       - --log.level=${TRAEFIK_LOG_LEVEL:-ERROR}
       - --providers.docker
       - --providers.docker.network=gateway


### PR DESCRIPTION
Related to https://github.com/Islandora-Devops/isle-site-template/issues/67

> `readTimeout` [is a new setting for traefik as of `v2.11.2`](https://doc.traefik.io/traefik/migration/v2/#entrypointtransportrespondingtimeoutsreadtimeout)
>
>I spent a lot of time tracking down why my setup was timing out on large file uploads (knowing it was working several months ago), and finally landed on this being the cause. Specifically, during my workbench ingest jobs the uploads were failing with
>
>```
>499 Client Closed Request' caused by: context canceled
>```
>
>Bumping this value beyond the default 60s got rid of the error.